### PR TITLE
Mock localizable generator

### DIFF
--- a/gwt-i18n/src/main/java/org/gwtproject/i18n/client/ConstantsWithLookup.java
+++ b/gwt-i18n/src/main/java/org/gwtproject/i18n/client/ConstantsWithLookup.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2008 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.gwtproject.i18n.client;
+
+import java.util.Map;
+import java.util.MissingResourceException;
+
+/**
+ * Like {@link com.google.gwt.i18n.client.Constants}, a tag interface that
+ * facilitates locale-sensitive, compile-time binding of constant values
+ * supplied from properties files with the added ability to look up constants at
+ * runtime with a string key.
+ *
+ * <p>
+ * <code>ConstantsWithLookup</code> extends
+ * {@link com.google.gwt.i18n.client.Constants} and is identical in behavior,
+ * adding only a family of special-purpose lookup methods such as
+ * {@link ConstantsWithLookup#getString(String)}.
+ * </p>
+ *
+ * <p>
+ * It is generally preferable to extend <code>Constants</code> rather than
+ * <code>ConstantsWithLookup</code> because <code>ConstantsWithLookup</code>
+ * forces all constants to be retained in the compiled script, preventing the
+ * GWT compiler from pruning unused constant accessors.
+ * </p>
+ *
+ * <h3>Required Module</h3>
+ * Modules that use this interface should inherit
+ * <code>com.google.gwt.i18n.I18N</code>.
+ *
+ * {@gwt.include com/google/gwt/examples/i18n/InheritsExample.gwt.xml}
+ *
+ * <h3>Note</h3>
+ * You should not directly implement this interface or interfaces derived from
+ * it since an implementation is generated automatically when message interfaces
+ * are created using {@link com.google.gwt.core.client.GWT#create(Class)}.
+ *
+ * @see com.google.gwt.i18n.client.Constants
+ */
+public interface ConstantsWithLookup extends Constants {
+    /**
+     * Look up <code>boolean</code> by method name.
+     *
+     * @param methodName method name
+     * @return boolean returned by method
+     * @throws MissingResourceException if methodName is not valid
+     */
+    boolean getBoolean(String methodName) throws MissingResourceException;
+
+    /**
+     * Look up <code>double</code> by method name.
+     *
+     * @param methodName method name
+     * @return double returned by method
+     * @throws MissingResourceException if methodName is not valid
+     */
+    double getDouble(String methodName) throws MissingResourceException;
+
+    /**
+     * Look up <code>float</code> by method name.
+     *
+     * @param methodName method name
+     * @return float returned by method
+     * @throws MissingResourceException if methodName is not valid
+     */
+    float getFloat(String methodName) throws MissingResourceException;
+
+    /**
+     * Look up <code>int</code> by method name.
+     *
+     * @param methodName method name
+     * @return int returned by method
+     * @throws MissingResourceException if methodName is not valid
+     */
+    int getInt(String methodName) throws MissingResourceException;
+
+    /**
+     * Look up <code>Map</code> by method name.
+     *
+     * @param methodName method name
+     * @return Map returned by method
+     * @throws MissingResourceException if methodName is not valid
+     */
+    Map<String, String> getMap(String methodName) throws MissingResourceException;
+
+    /**
+     * Look up <code>String</code> by method name.
+     *
+     * @param methodName method name
+     * @return String returned by method
+     * @throws MissingResourceException if methodName is not valid
+     */
+    String getString(String methodName) throws MissingResourceException;
+
+    /**
+     * Look up <code>String[]</code> by method name.
+     *
+     * @param methodName method name
+     * @return String[] returned by method
+     * @throws MissingResourceException if methodName is not valid
+     */
+    String[] getStringArray(String methodName) throws MissingResourceException;
+}

--- a/gwt-i18n/src/main/java/org/gwtproject/i18n/client/Localizable.java
+++ b/gwt-i18n/src/main/java/org/gwtproject/i18n/client/Localizable.java
@@ -20,8 +20,6 @@ package org.gwtproject.i18n.client;
  * 
  * deprecated use {@link org.gwtproject.i18n.shared.Localizable} instead
  */
-// Temporarily remove deprecation to keep from breaking teams that don't allow
-// deprecated references.
-// @Deprecated
+@Deprecated
 public interface Localizable extends org.gwtproject.i18n.shared.Localizable {
 }

--- a/gwt-i18n/src/main/java/org/gwtproject/i18n/client/Messages.java
+++ b/gwt-i18n/src/main/java/org/gwtproject/i18n/client/Messages.java
@@ -1,0 +1,412 @@
+package org.gwtproject.i18n.client;
+
+import java.lang.annotation.*;
+
+/**
+ * A tag interface that facilitates locale-sensitive, compile-time binding of
+ * messages supplied from various sources.Using
+ * <code>GWT.create(<i>class</i>)</code> to "instantiate" an interface that
+ * extends <code>Messages</code> returns an instance of an automatically
+ * generated subclass that is implemented using message templates selected based
+ * on locale. Message templates are based on a subset of the format used by <a
+ * href="http://download.oracle.com/javase/1.5.0/docs/api/java/text/MessageFormat.html">
+ * <code>MessageFormat</code></a>.  Note in particular that single quotes are
+ * used to quote other characters, and should be doubled for a literal single
+ * quote.
+ *
+ * <p>
+ * Locale is specified at run time using a meta tag or query string as described
+ * for {@link org.gwtproject.i18n.client.Localizable}.
+ * </p>
+ *
+ * <h3>Extending <code>Messages</code></h3>
+ * To use <code>Messages</code>, begin by defining an interface that extends
+ * it. Each interface method is referred to as a <i>message accessor</i>, and
+ * its corresponding message template is loaded based on the key for that
+ * method. The default key is simply the unqualified name of the method, but can
+ * be specified directly with an {@code @Key} annotation or a different
+ * generation method using {@code @GenerateKeys}. Additionally, if
+ * plural forms are used on a given method the plural form is added as a suffix
+ * to the key, such as <code>widgets[one]</code> for the singular version of
+ * the <code>widgets</code> message. The resulting key is used to find
+ * translated versions of the message from any supported input file, such as
+ * Java properties files. For example,
+ *
+ * {@example com.google.gwt.examples.i18n.GameStatusMessages}
+ *
+ * expects to find properties named <code>turnsLeft</code> and
+ * <code>currentScore</code> in an associated properties file, formatted as
+ * message templates taking two arguments and one argument, respectively. For
+ * example, the following properties would correctly bind to the
+ * <code>GameStatusMessages</code> interface:
+ *
+ * {@gwt.include com/google/gwt/examples/i18n/GameStatusMessages.properties}
+ *
+ * <p>
+ * The following example demonstrates how to use constant accessors defined in
+ * the interface above:
+ *
+ * {@example com.google.gwt.examples.i18n.GameStatusMessagesExample#beginNewGameRound(String)}
+ * </p>
+ *
+ * <p>The following example shows how to use annotations to store the default strings
+ * in the source file itself, rather than needing a properties file (you still need
+ * properties files for the translated strings):
+ *
+ * {@example com.google.gwt.examples.i18n.GameStatusMessagesAnnot}
+ * </p>
+ *
+ * <p>In this example, calling <code>msg.turnsLeft("John", 13)</code> would
+ * return the string <code>"Turns left for player 'John': 13"</code>.
+ * </p>
+ *
+ * <h3>Defining Message Accessors</h3>
+ * Message accessors must be of the form
+ *
+ * <pre>String methodName(<i>optional-params</i>)</pre>
+ *
+ * and parameters may be of any type. Arguments are converted into strings at
+ * runtime using Java string concatenation syntax (the '+' operator), which
+ * uniformly handles primitives, <code>null</code>, and invoking
+ * <code>toString()</code> to format objects.
+ *
+ * <p>
+ * Compile-time checks are performed to ensure that the number of placeholders
+ * in a message template (e.g. <code>{0}</code>) matches the number of
+ * parameters supplied.
+ * </p>
+ *
+ * <p>
+ * Integral arguments may be used to select the proper plural form to use for
+ * different locales. To do this, mark the particular argument with
+ * {@code @PluralCount} (a plural rule may be specified with
+ * {@code @PluralCount} if necessary, but you will almost never need to
+ * do this). The actual plural forms for the default locale can be supplied in a
+ * {@code @PluralText} annotation on the method, such as
+ * <code>@PluralText({"one", "You have one widget"})</code>, or they can be
+ * supplied in the properties file as {@code methodkey[one]=You have one widget}. Note
+ * that non-default plural forms are not inherited between locales, because the
+ * different locales may have different plural rules (especially {@code default} and
+ * anything else and those which use different scripts such as {@code sr_Cyrl} and
+ * {@code sr_Latn} [one of which would likely be the default], but also subtle cases
+ * like {@code pt} and {@code pt_BR}).
+ * </p>
+ *
+ * <p>
+ * Additionally, individual arguments can be marked as optional (ie, GWT will
+ * not give an error if a particular translation does not reference the
+ * argument) with the {@code @Optional} annotation, and an example may be supplied to
+ * the translator with the {@code @Example(String)} annotation.
+ * </p>
+ *
+ * <h3>Complete Annotations Example</h3>
+ * In addition to the default properties file, default text and additional
+ * metadata may be stored in the source file itself using annotations. A
+ * complete example of using annotations in this way is:
+ *
+ * <code><pre>
+ * &#64;Generate(format = "org.gwtproject.i18n.rebind.format.PropertiesFormat")
+ * &#64;DefaultLocale("en_US")
+ * public interface MyMessages extends Messages {
+ *   &#64;Key("1234")
+ *   &#64;DefaultMessage("This is a plain string.")
+ *   String oneTwoThreeFour();
+ *
+ *   &#64;DefaultMessage("You have {0} widgets")
+ *   &#64;PluralText({"one", "You have one widget")
+ *   String widgetCount(&#64;PluralCount int count);
+ *
+ *   &#64;DefaultMessage("No reference to the argument")
+ *   String optionalArg(&#64;Optional String ignored);
+ *
+ *   &#64;DefaultMessage("Your cart total is {0,number,currency}")
+ *   &#64;Description("The total value of the items in the shopping cart in local currency")
+ *   String totalAmount(&#64;Example("$5.00") double amount);
+ *
+ *   &#64;Meaning("the color")
+ *   &#64;DefaultMessage("orange")
+ *   String orangeColor();
+ *
+ *   &#64;Meaning("the fruit")
+ *   &#64;DefaultMessage("orange")
+ *   String orangeFruit();
+ * }
+ * </pre></code>
+ *
+ * <h3>Binding to Properties Files</h3>
+ * Interfaces extending <code>Messages</code> are bound to resource files
+ * using the same algorithm as interfaces extending <code>Constants</code>.
+ * See the documentation for {@link Constants} for a description of the
+ * algorithm.
+ *
+ * <h3>Required Module</h3>
+ * Modules that use this interface should inherit
+ * <code>org.gwtproject.i18n.I18N</code>.
+ *
+ * {@gwt.include com/google/gwt/examples/i18n/InheritsExample.gwt.xml}
+ *
+ * <h3>Note</h3>
+ * You should not directly implement this interface or interfaces derived from
+ * it since an implementation is generated automatically when message interfaces
+ * are created using {@link com.google.gwt.core.client.GWT#create(Class)}.
+ */
+public interface Messages extends LocalizableResource {
+
+    /**
+     * Provides alternate forms of a message, such as are needed when plural
+     * forms are used or a placeholder has known gender. The selection of which
+     * form to use is based on the value of the arguments marked
+     * PluralCount and/or Select.
+     *
+     * <p>Example:
+     * <code><pre>
+     *   &#64;DefaultMessage("You have {0} widgets.")
+     *   &#64;AlternateMessage({"one", "You have one widget.")
+     *   String example(&#64;PluralCount int count);
+     * </pre></code>
+     * </p>
+     *
+     * <p>If multiple {@link PluralCount} or {@link Select} parameters are
+     * supplied, the forms for each, in the order they appear in the parameter
+     * list, are supplied separated by a vertical bar ("|").  Example:
+     * <code><pre>
+     *   &#64;DefaultMessage("You have {0} messages and {1} notifications.")
+     *   &#64;AlternateMessage({
+     *       "=0|=0", "You have no messages or notifications."
+     *       "=0|one", "You have a notification."
+     *       "one|=0", "You have a message."
+     *       "one|one", "You have one message and one notification."
+     *       "other|one", "You have {0} messages and one notification."
+     *       "one|other", "You have one message and {1} notifications."
+     *   })
+     *   String messages(&#64;PluralCount int msgCount,
+     *       &#64;PluralCount int notifyCount);
+     * </pre></code>
+     *
+     * Note that the number of permutations can grow quickly, and that the default
+     * message is used when every {@link PluralCount} or {@link Select} would use
+     * the "other" value.
+     * </p>
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    @Documented
+    public @interface AlternateMessage {
+
+        /**
+         * An array of pairs of strings containing the strings for different forms.
+         *
+         * Each pair is the name of a form followed by the string in the source
+         * locale for that form.  Each form name is the name of a plural form if
+         * {@link PluralCount} is used, or the matching value if {@link Select} is
+         * used.  An example for a locale that has "none", "one", and "other" plural
+         * forms:
+         *
+         * <code><pre>
+         * &#64;DefaultMessage("{0} widgets")
+         * &#64;AlternateMessage({"none", "No widgets", "one", "One widget"})
+         * </pre>
+         *
+         * Note that the plural form "other" gets the translation specified in
+         * {@code &#64;DefaultMessage}, as does any {@code &#64;Select} value not
+         * listed.
+         *
+         * If more than one way of selecting a translation exists, they will be
+         * combined, separated with {@code |}, in the order they are supplied as
+         * arguments in the method.  For example:
+         * <code><pre>
+         *   &#64;DefaultMessage("{0} gave away their {2} widgets")
+         *   &#64;AlternateMesssage({
+         *     "MALE|other", "{0} gave away his {2} widgets",
+         *     "FEMALE|other", "{0} gave away her {2} widgets",
+         *     "MALE|one", "{0} gave away his widget",
+         *     "FEMALE|one", "{0} gave away her widget",
+         *     "other|one", "{0} gave away their widget",
+         *   })
+         *   String giveAway(String name, &#64;Select Gender gender,
+         *       &#64;PluralCount int count);
+         * </pre></code>
+         */
+        String[] value();
+    }
+
+    /**
+     * Default text to be used if no translation is found (and also used as the
+     * source for translation). Format should be that expected by
+     * {@link java.text.MessageFormat}.
+     *
+     * <p>Example:
+     * <code><pre>
+     *   &#64;DefaultMessage("Don''t panic - you have {0} widgets left")
+     *   String example(int count)
+     * </pre></code>
+     * </p>
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    @Documented
+    public @interface DefaultMessage {
+        String value();
+    }
+
+    /**
+     * An example of the annotated parameter to assist translators.
+     *
+     * <p>Example:
+     * <code><pre>
+     *   String example(&#64;Example("/etc/passwd") String fileName)
+     * </pre></code>
+     * </p>
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.PARAMETER)
+    public @interface Example {
+        String value();
+    }
+
+    /**
+     * Ignored except on parameters also tagged with {@link PluralCount}, and
+     * provides an offset to be subtracted from the value before a plural rule
+     * is chosen or the value is formatted.  Note that "=n" forms are evaluated
+     * before this offset is applied.
+     *
+     * <p>Example:
+     * <code><pre>
+     *   &#64;PluralText({"=0", "No one has recommended this movie",
+     *     "=1", "{0} has recommended this movie",
+     *     "=2", "{0} and {1} have recommended this movie",
+     *     "one", "{0}, {1} and one other have recommended this movie"})
+     *   &#64;DefaultMessage("{0}, {1} and {2,number} others have recommended this movie")
+     *   String recommenders(&#64;Optional String rec1, &#64;Optional String rec2,
+     *     &#64;PluralCount &#64;Offset(2) int count);
+     * </pre></code>
+     * would result in
+     * <code><pre>
+     * recommenders("John", null, 1) => "John has..."
+     * recommenders("John", "Jane", 3) => "John, Jane, and one other..."
+     * recommenders("John", "Jane", 1402) => "John, Jane, and 1,400 others..."
+     * </pre></code>
+     * </p>
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.PARAMETER)
+    public @interface Offset {
+        int value();
+    }
+
+    /**
+     * Indicates the specified parameter is optional and need not appear in a
+     * particular translation of this message.
+     *
+     * <p>Example:
+     * <code><pre>
+     *   String example(&#64;Optional int count)
+     * </pre></code>
+     * </p>
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.PARAMETER)
+    public @interface Optional {
+    }
+
+    /**
+     * Provides multiple plural forms based on a count. The selection of which
+     * plural form is performed by a PluralRule implementation.
+     *
+     * This annotation is applied to a single parameter of a Messages subinterface
+     * and indicates that parameter is to be used to choose the proper plural form
+     * of the message. The parameter chosen must be of type short or int.
+     *
+     * Optionally, a class literal referring to a PluralRule implementation can be
+     * supplied as the argument if the standard implementation is insufficient.
+     *
+     * <p>Example:
+     * <code><pre>
+     *   &#64;DefaultMessage("You have {0} widgets.")
+     *   &#64;AlternateMessage({"one", "You have one widget."})
+     *   String example(&#64;PluralCount int count)
+     * </pre></code>
+     * </p>
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.PARAMETER)
+    public @interface PluralCount {
+
+        /**
+         * The PluralRule implementation to use for this message. If not specified,
+         * the GWT-supplied one is used instead, which should cover most use cases.
+         *
+         * <p>{@code PluralRule.class} is used as a default value here, which will
+         * be replaced during code generation with the default implementation.
+         * </p>
+         */
+        // http://bugs.sun.com/view_bug.do?bug_id=6512707
+        Class<? extends PluralRule> value() default org.gwtproject.i18n.client.PluralRule.class;
+    }
+
+    /**
+     * Provides multiple plural forms based on a count. The selection of which
+     * plural form to use is based on the value of the argument marked
+     * PluralCount, which may also specify an alternate plural rule to use.
+     *
+     * <p>Example:
+     * <code><pre>
+     *   &#64;DefaultMessage("You have {0} widgets.")
+     *   &#64;PluralText({"one", "You have one widget.")
+     *   String example(&#64;PluralCount int count)
+     * </pre></code>
+     * </p>
+     *
+     * @deprecated use {@link AlternateMessage} instead
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    @Documented
+    @Deprecated
+    public @interface PluralText {
+
+        /**
+         * An array of pairs of strings containing the strings for different plural
+         * forms.
+         *
+         * Each pair is the name of the plural form (as returned by
+         * PluralForm.toString) followed by the string for that plural form. An
+         * example for a locale that has "none", "one", and "other" plural forms:
+         *
+         * <code><pre>
+         * &#64;DefaultMessage("{0} widgets")
+         * &#64;PluralText({"none", "No widgets", "one", "One widget"})
+         * </pre>
+         *
+         * "other" must not be included in this array as it will map to the
+         * DefaultMessage value.
+         */
+        String[] value();
+    }
+
+    /**
+     * Provides multiple forms based on a dynamic parameter.
+     *
+     * This annotation is applied to a single parameter of a Messages subinterface
+     * and indicates that parameter is to be used to choose the proper form of the
+     * message. The parameter chosen must be of type Enum, String, boolean, or a
+     * primitive integral type.  This is frequently used to get proper gender for
+     * translations to languages where surrounding words depend on the gender of
+     * a person or noun.  This also marks the parameter as {@link Optional}.
+     *
+     * <p>Example:
+     * <code><pre>
+     *   &#64;DefaultMessage("{0} likes their widgets.")
+     *   &#64;AlternateMessage({
+     *       "FEMALE", "{0} likes her widgets.",
+     *       "MALE", "{0} likes his widgets.",
+     *   })
+     *   String example(String name, &#64;Select Gender gender)
+     * </pre></code>
+     * </p>
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.PARAMETER)
+    public @interface Select {
+    }
+}

--- a/gwt-i18n/src/main/java/org/gwtproject/i18n/client/PluralRule.java
+++ b/gwt-i18n/src/main/java/org/gwtproject/i18n/client/PluralRule.java
@@ -1,0 +1,90 @@
+package org.gwtproject.i18n.client;
+
+/**
+ * The interface that plural rules must implement.  Implementations of
+ * this interface will be used both at compile time (pluralForms) and
+ * at run time (select), so implementations must be both translatable
+ * and not reference JSNI methods.
+ */
+public interface PluralRule {
+
+    /**
+     * Information about the plural forms supported by this rule which
+     * will be used during code generation and by tools to provide
+     * information to translators.
+     */
+    public static class PluralForm {
+        private final String name;
+        private final String description;
+        private final boolean noWarn;
+
+        /**
+         * Create the plural form.
+         *
+         * @param name
+         * @param description
+         */
+        public PluralForm(String name, String description) {
+            this(name, description, false);
+        }
+
+        /**
+         * Create the plural form.
+         *
+         * @param name
+         * @param description
+         * @param noWarn if true, do not warn if this form is missing from a
+         *     translation.  This is used for those cases where a plural form
+         *     is defined for a language, but is very rarely used.
+         */
+        public PluralForm(String name, String description, boolean noWarn) {
+            this.name = name;
+            this.description = description;
+            this.noWarn = noWarn;
+        }
+
+        /**
+         * Returns the description.
+         */
+        public String getDescription() {
+            return description;
+        }
+
+        /**
+         * Returns the name.
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * Returns true if the generator should warn if this plural form is not
+         * present.
+         */
+        public boolean getWarnIfMissing() {
+            return !noWarn;
+        }
+    }
+
+    /**
+     * Returns the list of values which are valid for this rule.  The
+     * default or "other" plural form must be first in the list with
+     * an index of 0 -- this form will be used if no other form applies
+     * and is also mapped to the default text for a given message.
+     *
+     * This method will be executed at compile time and may not contain
+     * any references, even indirectly, to JSNI methods.
+     */
+    PluralForm[] pluralForms();
+
+    /**
+     * Returns the plural form appropriate for this count.
+     *
+     * This method will be executed at runtime, so must be translatable.
+     *
+     * @param n count of items to choose plural form for
+     * @return the plural form to use (must be a valid index
+     *     into the array returned by pluralForms).
+     */
+    int select(int n);
+}

--- a/gwt-i18n/src/main/java/org/gwtproject/i18n/shared/Localizable.java
+++ b/gwt-i18n/src/main/java/org/gwtproject/i18n/shared/Localizable.java
@@ -15,6 +15,8 @@
  */
 package org.gwtproject.i18n.shared;
 
+import java.lang.annotation.*;
+
 /**
  * A tag interface that serves as the root of a family of types used in static
  * internationalization. Using <code>GWT.create(<i>class</i>)</code> to
@@ -101,5 +103,17 @@ package org.gwtproject.i18n.shared;
  * @see org.gwtproject.i18n.client.Messages
  * @see org.gwtproject.i18n.client.Dictionary
  */
+@Localizable.I18nLocaleSuffuxes({"default", "en", "es", "fr", "de"})//TODO real list
 public interface Localizable {
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @Documented
+    @interface IsLocalizable {}
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @Documented
+    @interface I18nLocaleSuffuxes {
+        String[] value();
+    }
 }

--- a/gwt-i18n/src/main/java/org/gwtproject/i18n/shared/Localizable.java
+++ b/gwt-i18n/src/main/java/org/gwtproject/i18n/shared/Localizable.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2007 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.gwtproject.i18n.shared;
+
+/**
+ * A tag interface that serves as the root of a family of types used in static
+ * internationalization. Using <code>GWT.create(<i>class</i>)</code> to
+ * instantiate a type that directly extends or implements
+ * <code>Localizable</code> invites locale-sensitive type substitution.
+ *
+ * <h3>Locale-sensitive Type Substitution</h3>
+ * If a type <code>Type</code> directly extends or implements
+ * <code>Localizable</code> (as opposed to
+ * {@link org.gwtproject.i18n.client.Constants} or
+ * {@link org.gwtproject.i18n.client.Messages}) and the following code is used
+ * to create an object from <code>Type</code> as follows:
+ *
+ * <pre class="code">Type localized = (Type)GWT.create(Type.class);</pre>
+ *
+ * then <code>localized</code> will be assigned an instance of a localized
+ * subclass, selected based on the value of the <code>locale</code> client
+ * property. The choice of subclass is determined by the following naming
+ * pattern:
+ *
+ * <table>
+ *
+ * <tr>
+ * <th align='left'>If <code>locale</code> is...&#160;&#160;&#160;&#160;</th>
+ * <th align='left'>The substitute class for <code>Type</code> is...</th>
+ * </tr>
+ *
+ * <tr>
+ * <td><i>unspecified</i></td>
+ * <td><code>Type</code> itself, or <code>Type_</code> if <code>Type</code>
+ * is an interface</td>
+ * </tr>
+ *
+ * <tr>
+ * <td><code>x</code></td>
+ * <td>Class <code>Type_x</code> if it exists, otherwise treated as if
+ * <code>locale</code> were <i>unspecified</i></td>
+ * </tr>
+ *
+ * <tr>
+ * <td><code>x_Y</code></td>
+ * <td>Class <code>Type_x_Y</code> if it exists, otherwise treated as if
+ * <code>locale</code> were <code>x</code></td>
+ * </tr>
+ *
+ * </table>
+ *
+ * where in the table above <code>x</code> is a <a
+ * href="http://ftp.ics.uci.edu/pub/ietf/http/related/iso639.txt">ISO language
+ * code</a> and <code>Y</code> is a two-letter <a
+ * href="http://userpage.chemie.fu-berlin.de/diverse/doc/ISO_3166.html">ISO
+ * country code</a>.
+ *
+ * <h3>Specifying Locale</h3>
+ * The locale of a module is specified using the <code>locale</code> client
+ * property, which can be specified using either a meta tag or as part of the
+ * query string in the host page's URL. If both are specified, the query string
+ * takes precedence.
+ *
+ * <p>
+ * To specify the <code>locale</code> client property using a meta tag in the
+ * host HTML, use <code>gwt:property</code> as follows:
+ *
+ * <pre>&lt;meta name="gwt:property" content="locale.new=x_Y"&gt;</pre>
+ *
+ * For example, the following host HTML page sets the locale to "ja_JP":
+ *
+ * {@gwt.include com/google/gwt/examples/i18n/ColorNameLookupExample_ja_JP.html}
+ * </p>
+ *
+ * <p>
+ * To specify the <code>locale</code> client property using a query string,
+ * specify a value for the name <code>locale</code>. For example,
+ *
+ * <pre>http://www.example.org/myapp.html?locale=fr_CA</pre>
+ *
+ * </p>
+ *
+ * <h3>For More Information</h3>
+ * See the GWT Developer Guide for an introduction to internationalization.
+ *
+ * @see org.gwtproject.i18n.client.Constants
+ * @see org.gwtproject.i18n.client.ConstantsWithLookup
+ * @see org.gwtproject.i18n.client.Messages
+ * @see org.gwtproject.i18n.client.Dictionary
+ */
+public interface Localizable {
+}

--- a/gwt-localizable-processor/pom.xml
+++ b/gwt-localizable-processor/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.gwtproject.i18n</groupId>
+        <artifactId>gwt-i18n-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>gwt-localizable-processor</artifactId>
+
+    <properties>
+        <javapoet.version>1.4.0</javapoet.version>
+        <auto.common.version>0.8</auto.common.version>
+        <auto.service.version>1.0-rc2</auto.service.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.gwtproject.i18n</groupId>
+            <artifactId>gwt-i18n</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup</groupId>
+            <artifactId>javapoet</artifactId>
+            <version>${javapoet.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto</groupId>
+            <artifactId>auto-common</artifactId>
+            <version>${auto.common.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <version>${auto.service.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.gwtproject.i18n</groupId>
+            <artifactId>gwt-i18n-processor-util</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-user</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-dev</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <configuration>
+                    <testFailureIgnore>true</testFailureIgnore>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gwt-localizable-processor/src/main/java/org/gwtproject/i18n/processor/LocalizableProcessingStep.java
+++ b/gwt-localizable-processor/src/main/java/org/gwtproject/i18n/processor/LocalizableProcessingStep.java
@@ -1,0 +1,151 @@
+package org.gwtproject.i18n.processor;
+
+import com.google.auto.common.BasicAnnotationProcessor;
+import com.google.auto.common.MoreElements;
+import com.google.common.collect.SetMultimap;
+import com.squareup.javapoet.*;
+import org.gwtproject.i18n.shared.Localizable;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
+import javax.tools.Diagnostic;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class LocalizableProcessingStep implements BasicAnnotationProcessor.ProcessingStep {
+    private final ProcessingEnvironment processingEnv;
+
+    public LocalizableProcessingStep(ProcessingEnvironment processingEnv) {
+        this.processingEnv = processingEnv;
+    }
+
+    @Override
+    public Set<? extends Class<? extends Annotation>> annotations() {
+        return Collections.singleton(Localizable.IsLocalizable.class);
+    }
+
+    @Override
+    public Set<Element> process(SetMultimap<Class<? extends Annotation>, Element> elementsByAnnotation) {
+
+        for (Element element : elementsByAnnotation.get(Localizable.IsLocalizable.class)) {
+            // build a model
+            String packageName = processingEnv.getElementUtils().getPackageOf(element).getQualifiedName().toString();
+
+            // collect the possible locales
+            //TODO correctly sort this based on the logic ahmad has worked up
+
+            List<String> locales = getLocaleNames(element);
+            // TODO remove hack which restricts us to default
+            locales = Collections.singletonList("default");
+
+
+            // implement the interface into a new type for each locale key
+            Map<String, ClassName> keyToNameMapping = new HashMap<>();
+
+
+            keyToNameMapping.put("default", ClassName.get(packageName, element.getSimpleName().toString() + "_default"));
+
+            TypeSpec.Builder defaultImplBuilder = TypeSpec.classBuilder(element.getSimpleName().toString() + "_default")
+                    .addModifiers(Modifier.PUBLIC)
+                    .addSuperinterface(ClassName.get(element.asType()));
+
+            MoreElements.getLocalAndInheritedMethods((TypeElement) element, processingEnv.getTypeUtils(), processingEnv.getElementUtils())
+                    .stream()
+//                    .filter(method -> !method.getModifiers().contains(Modifier.STATIC))
+                    .filter(method -> !method.getModifiers().contains(Modifier.DEFAULT))
+
+                    // skip anything on Object
+                    .filter(method -> !Object.class.getName().equals(ClassName.get(method.getEnclosingElement().asType()).toString()))
+                    .forEach(method -> {
+                        MethodSpec.Builder impl = MethodSpec.methodBuilder(method.getSimpleName().toString())
+                                .addModifiers(Modifier.PUBLIC)
+                                .returns(TypeName.get(method.getReturnType()))
+                                .addAnnotation(Override.class);
+                        for (VariableElement parameter : method.getParameters()) {
+                            impl.addParameter(TypeName.get(parameter.asType()), parameter.getSimpleName().toString());
+                        }
+                        //TODO support other return types, return correct values, etc
+                        if (method.getReturnType().getKind().isPrimitive()) {
+                            if (method.getReturnType().getKind() == TypeKind.BOOLEAN) {
+                                impl.addStatement("return false");
+                            } else {
+                                impl.addStatement("return ($T)0", TypeName.get(method.getReturnType()));
+                            }
+                        } else {
+
+                            impl.addStatement("return $S", method.getSimpleName().toString());
+                        }
+
+                        defaultImplBuilder.addMethod(impl.build());
+                    });
+
+            try {
+                JavaFile.builder(packageName, defaultImplBuilder.build()).build().writeTo(processingEnv.getFiler());
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+            // for each method that needs overriding, generate a method which
+            // either reads from the default annotation or just returns the
+            // method name itself, ignoring all args
+
+            // based on the types created and their locale,
+            // create a factor
+            TypeSpec factory = TypeSpec.classBuilder(element.getSimpleName() + "_Factory")
+                    .addMethod(MethodSpec.methodBuilder("create")
+                            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                            .returns(ClassName.get(element.asType()))
+                            .addStatement("return create(System.getProperty(\"locale\", \"default\"))")
+                            .build())
+                    .addMethod(MethodSpec.methodBuilder("create")
+                            .addParameter(String.class, "locale")
+                            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                            .returns(ClassName.get(element.asType()))
+                            .addCode(makeSwitchCase(locales, keyToNameMapping))
+                            .build())
+                    .build();
+            try {
+                JavaFile.builder(packageName, factory).build().writeTo(processingEnv.getFiler());
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        return Collections.emptySet();
+    }
+
+    private List<String> getLocaleNames(Element element) {
+        //breadth-first search to find the annotation since you can have diamond inheritance in interfaces
+        List<Element> typesToCheck = new ArrayList<>();
+        typesToCheck.add(element);
+        for (int i = 0; i < typesToCheck.size(); i++) {
+            Element check = typesToCheck.get(i);
+            Localizable.I18nLocaleSuffuxes annotation = check.getAnnotation(Localizable.I18nLocaleSuffuxes.class);
+            if (annotation != null) {
+                return Arrays.asList(annotation.value());
+            }
+            TypeElement type = (TypeElement) check;
+            typesToCheck.addAll(type.getInterfaces().stream().map(m -> processingEnv.getTypeUtils().asElement(m)).collect(Collectors.toList()));
+        }
+        return Collections.emptyList();
+    }
+
+    private CodeBlock makeSwitchCase(List<String> locales, Map<String, ClassName> keyToNameMapping) {
+        CodeBlock.Builder switchCase = CodeBlock.builder().beginControlFlow("switch (locale)");
+        for (String locale : locales) {
+            switchCase.beginControlFlow("case $S:", locale)
+                    .addStatement("return new $T()", keyToNameMapping.get(locale))
+                    .endControlFlow();
+        }
+        return switchCase.endControlFlow()
+                .addStatement("return null").build();
+    }
+}

--- a/gwt-localizable-processor/src/main/java/org/gwtproject/i18n/processor/LocalizableProcessor.java
+++ b/gwt-localizable-processor/src/main/java/org/gwtproject/i18n/processor/LocalizableProcessor.java
@@ -1,0 +1,21 @@
+package org.gwtproject.i18n.processor;
+
+import com.google.auto.common.BasicAnnotationProcessor;
+import com.google.auto.service.AutoService;
+
+import javax.annotation.processing.Processor;
+import javax.lang.model.SourceVersion;
+import java.util.Collections;
+
+@AutoService(Processor.class)
+public class LocalizableProcessor extends BasicAnnotationProcessor {
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
+
+    @Override
+    protected Iterable<? extends ProcessingStep> initSteps() {
+        return Collections.singleton(new LocalizableProcessingStep(processingEnv));
+    }
+}

--- a/gwt-localizable-processor/src/test/java/org/gwtproject/i18n/client/AnnotationsTest.java
+++ b/gwt-localizable-processor/src/test/java/org/gwtproject/i18n/client/AnnotationsTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2008 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.gwtproject.i18n.client;
+
+import com.google.gwt.core.client.GWT;
+import org.gwtproject.i18n.client.LocalizableResource.DefaultLocale;
+import com.google.gwt.junit.client.GWTTestCase;
+import org.gwtproject.i18n.shared.Localizable;
+
+/**
+ * Tests annotations not covered elsewhere.
+ */
+public class AnnotationsTest extends GWTTestCase {
+
+    /**
+     * First grandparent for test.
+     */
+    public interface GP1 extends TestConstants {
+        @Constants.DefaultStringValue("gp1 annot")
+        String gp1();
+
+        @Constants.DefaultStringValue("gp1 shared annot")
+        String shared();
+    }
+
+    /**
+     * Second grandparent for test.
+     */
+    public interface GP2 extends TestConstants {
+        @Constants.DefaultStringValue("gp2 annot")
+        String gp2();
+
+        @Constants.DefaultStringValue("gp2 shared annot")
+        String shared();
+    }
+
+    /**
+     * Test interface for P1 before P2.
+     */
+    @Localizable.IsLocalizable
+    public interface Inherit1 extends P1, P2 {
+    }
+
+    /**
+     * Test interface for P2 before P1.
+     */
+    @Localizable.IsLocalizable
+    public interface Inherit2 extends P2, P1 {
+        @Constants.DefaultStringValue("def")
+        String def();
+    }
+
+    /**
+     * Used to verify that we can explicitly localize messages in annotations.
+     */
+    @DefaultLocale("en")
+    public interface Inherit2_en extends Inherit2 {
+        @Override
+        @Constants.DefaultStringValue("en def")
+        String def();
+    }
+
+    /**
+     * First parent interface for test.
+     */
+    public interface P1 extends TestConstants {
+        @Constants.DefaultStringValue("p1 annot")
+        String p1();
+
+        @Constants.DefaultStringValue("p1 shared annot")
+        String shared();
+    }
+
+    /**
+     * Second parent interface for test.
+     */
+    public interface P2 extends GP1, GP2 {
+        @Constants.DefaultStringValue("p2 annot")
+        String p2();
+
+        @Override
+        String shared();
+    }
+
+    /**
+     * Basic test message.
+     */
+    public interface Msg1 extends Messages {
+        @DefaultMessage("Test {0}")
+        String getTest(String testName);
+    }
+
+    /**
+     * Plural form test message.
+     */
+    public interface Msg2 extends Messages {
+        @DefaultMessage("You have {0} widgets.")
+        @PluralText({"one", "You have a widget."})
+        String getWidgetCount(@PluralCount int count);
+
+        @DefaultMessage("from en")
+        String leastDerived();
+    }
+
+    /**
+     * Aggregate messages into one interface.
+     */
+    @Localizable.IsLocalizable
+    public interface AllMessages extends Msg1, Msg2 {
+    }
+
+    @Override
+    public String getModuleName() {
+        return null;//"org.gwtproject.i18n.I18NTest_en";
+    }
+
+    public void testInheritance() {
+        Inherit1 i1 = Inherit1_Factory.create();
+        assertEquals("p1 annot", i1.p1());
+        assertEquals("gp2 annot", i1.gp2());
+        assertEquals("p1 shared annot", i1.shared());
+        Inherit2 i2 = Inherit2_Factory.create();
+        assertEquals("p1 annot", i2.p1());
+        assertEquals("gp2 annot", i2.gp2());
+        assertEquals("gp1 shared annot", i2.shared());
+
+        // TODO(jat): this doesn't work because findDerivedClasses only
+        // looks for concrete classes, not other interfaces -- commenting
+        // out for now, revisit later.
+        // assertEquals("en def", i2.def());
+    }
+
+    public void testIssue2359() {
+        AllMessages m = AllMessages_Factory.create();
+        assertEquals("Test foo", m.getTest("foo"));
+        assertEquals("You have 2 widgets.", m.getWidgetCount(2));
+        assertEquals("You have a widget.", m.getWidgetCount(1));
+    }
+
+    public void testLeastDerived() {
+        AllMessages m = AllMessages_Factory.create();
+        assertEquals("from en_US", m.leastDerived());
+    }
+}

--- a/gwt-localizable-processor/src/test/java/org/gwtproject/i18n/client/TestConstants.java
+++ b/gwt-localizable-processor/src/test/java/org/gwtproject/i18n/client/TestConstants.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2007 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.gwtproject.i18n.client;
+
+import org.gwtproject.i18n.client.LocalizableResource.Generate;
+
+import java.util.Map;
+
+/**
+ * Interface to represent the contents of resourcePattern bundle
+ * org/gwtproject/i18n/client/TestConstants.properties.
+ */
+@Generate(format = "org.gwtproject.i18n.server.PropertyCatalogFactory")
+public interface TestConstants extends org.gwtproject.i18n.client.Constants {
+
+    boolean booleanFalse();
+
+    boolean booleanTrue();
+
+    double doubleNegMax();
+
+    double doubleNegMin();
+
+    double doubleNegOne();
+
+    double doubleOne();
+
+    double doublePi();
+
+    double doublePosMax();
+
+    double doublePosMin();
+
+    double doubleZero();
+
+    float floatNegMax();
+
+    float floatNegMin();
+
+    float floatNegOne();
+
+    float floatOne();
+
+    float floatPi();
+
+    float floatPosMax();
+
+    float floatPosMin();
+
+    float floatZero();
+
+    @Key("string")
+    String getString();
+
+    int intMax();
+
+    int intMin();
+
+    int intNegOne();
+
+    int intOne();
+
+    int intZero();
+
+//    Map<String, String> mapABCD();
+//
+//    Map<String, String> mapBACD();
+//
+//    Map<String, String> mapBBB();
+//
+//    // raw type test
+//    @SuppressWarnings("unchecked")
+//    Map mapDCBA();
+//
+//    Map<String, String> mapEmpty();
+//
+//    // Map<String, String> mapWithMissingKey();
+//
+//    Map<String, String> mapXYZ();
+//
+//    String[] stringArrayABCDEFG();
+//
+//    String[] stringArraySizeOneEmptyString();
+//
+//    String[] stringArraySizeOneWithBackslashX();
+//
+//    String[] stringArraySizeOneX();
+//
+//    String[] stringArraySizeThreeAllEmpty();
+//
+//    String[] stringArraySizeThreeWithDoubleBackslash();
+//
+//    String[] stringArraySizeTwoBothEmpty();
+//
+//    String[] stringArraySizeTwoWithEscapedComma();
+
+    String stringDoesNotTrimTrailingThreeSpaces();
+
+    String stringEmpty();
+
+    String stringJapaneseBlue();
+
+    String stringJapaneseGreen();
+
+    String stringJapaneseRed();
+
+    String stringTrimsLeadingWhitespace();
+}


### PR DESCRIPTION
This branch also includes some missing interfaces (at least one was in the cldr repo instead), and some new annotations we've discussed adding.

All it does for now is return the method name (if the method returns a string) otherwise returns 0 or false for any primitive type. No more interesting methods are supported.

One test was copied over, and it does correctly _compile_, but it fails when run. Does not require GWT2 at all any more, though we probably will want to run it in GWT2 and j2cl just to feel better about the setup?