### PR TITLE
re-run fmt:format and apply missing copyright headers

### DIFF
--- a/gwt-datetimeformat-processor/src/main/java/org/gwtproject/i18n/datetimeformat/processor/CustomDateTimeFormatProcessingStep.java
+++ b/gwt-datetimeformat-processor/src/main/java/org/gwtproject/i18n/datetimeformat/processor/CustomDateTimeFormatProcessingStep.java
@@ -15,12 +15,21 @@
  */
 package org.gwtproject.i18n.datetimeformat.processor;
 
+import static java.util.Objects.nonNull;
+
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.util.*;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.*;
+import javax.lang.model.type.TypeMirror;
+import javax.tools.Diagnostic;
 import org.gwtproject.ext.PropertyOracle;
 import org.gwtproject.ext.PropertyOracleImpl;
 import org.gwtproject.i18n.processor.*;
@@ -30,127 +39,128 @@ import org.gwtproject.i18n.shared.GwtLocale;
 import org.gwtproject.i18n.shared.SupportedLocales;
 import org.gwtproject.i18n.shared.annotations.IsCustomDateTimeFormat;
 
-import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.*;
-import javax.lang.model.type.TypeMirror;
-import javax.tools.Diagnostic;
-import java.io.IOException;
-import java.lang.annotation.Annotation;
-import java.util.*;
-
-import static java.util.Objects.nonNull;
-
-/**
- * Created by colin on 7/17/16.
- */
+/** Created by colin on 7/17/16. */
 public class CustomDateTimeFormatProcessingStep extends AbstractProcessingStep {
 
+  public CustomDateTimeFormatProcessingStep(ProcessingEnvironment processingEnv) {
+    super(processingEnv);
+  }
 
-    public CustomDateTimeFormatProcessingStep(ProcessingEnvironment processingEnv) {
-        super(processingEnv);
+  public static class Builder extends StepBuilder<CustomDateTimeFormatProcessingStep> {
+
+    public CustomDateTimeFormatProcessingStep build() {
+      return new CustomDateTimeFormatProcessingStep(processingEnv);
+    }
+  }
+
+  @Override
+  public Set<? extends Class<? extends Annotation>> annotations() {
+    return Collections.singleton(IsCustomDateTimeFormat.class);
+  }
+
+  @Override
+  public Set<Element> process(
+      SetMultimap<Class<? extends Annotation>, Element> elementsByAnnotation) {
+
+    for (Element element : elementsByAnnotation.get(IsCustomDateTimeFormat.class)) {
+      try {
+        generateCustomDateTimeFormats((TypeElement) element);
+      } catch (IOException e) {
+        ExceptionUtil.messageStackTrace(messager, e);
+      }
     }
 
-    public static class Builder extends StepBuilder<CustomDateTimeFormatProcessingStep> {
+    return ImmutableSet.of();
+  }
 
-        public CustomDateTimeFormatProcessingStep build() {
-            return new CustomDateTimeFormatProcessingStep(processingEnv);
-        }
+  private void generateCustomDateTimeFormats(TypeElement element) throws IOException {
+
+    TypeElement dateTimeFormat = elements.getTypeElement(DateTimeFormat.class.getName());
+    // TODO(jat): runtime locales support
+    List<String> supportedLocales = getSupportedLocales(element);
+
+    supportedLocales.forEach(
+        locale -> {
+          DateTimePatternGenerator dtpg = getDateTimePatternGenerator(locale);
+          String className = element.getSimpleName().toString().replace('.', '_') + "_" + locale;
+
+          TypeSpec.Builder typeBuilder =
+              TypeSpec.classBuilder(className)
+                  .addModifiers(Modifier.PUBLIC)
+                  .addSuperinterface(TypeName.get(element.asType()));
+
+          element
+              .getEnclosedElements()
+              .stream()
+              .filter(e -> ElementKind.METHOD.equals(e.getKind()))
+              .map(e -> (ExecutableElement) e)
+              .forEach(
+                  method -> {
+                    TypeMirror returnType = method.getReturnType();
+                    if (!types.isSameType(returnType, dateTimeFormat.asType())) {
+                      messager.printMessage(
+                          Diagnostic.Kind.ERROR,
+                          element.getQualifiedName()
+                              + "."
+                              + method.getSimpleName().toString()
+                              + " must return DateTimeFormat");
+                    }
+                    String pattern;
+                    CustomDateTimeFormat.Pattern annotation =
+                        method.getAnnotation(CustomDateTimeFormat.Pattern.class);
+                    if (annotation == null) {
+                      messager.printMessage(
+                          Diagnostic.Kind.ERROR,
+                          element.getQualifiedName()
+                              + "."
+                              + method.getSimpleName()
+                              + " must have an @Pattern annotation");
+                    }
+                    pattern = annotation.value();
+                    pattern = dtpg.getBestPattern(pattern);
+
+                    typeBuilder.addMethod(
+                        MethodSpec.methodBuilder(method.getSimpleName().toString())
+                            .addAnnotation(Override.class)
+                            .addModifiers(Modifier.PUBLIC)
+                            .returns(TypeName.get(method.getReturnType()))
+                            .addStatement(
+                                "return $T.getFormat(\"$L\")",
+                                TypeName.get(method.getReturnType()),
+                                pattern)
+                            .build());
+                  });
+
+          JavaFile driverFile =
+              JavaFile.builder(
+                      elements.getPackageOf(element).getQualifiedName().toString(),
+                      typeBuilder.build())
+                  .build();
+
+          try {
+            driverFile.writeTo(filer);
+          } catch (IOException e) {
+            ExceptionUtil.messageStackTrace(messager, e);
+          }
+        });
+  }
+
+  private List<String> getSupportedLocales(TypeElement element) {
+    SupportedLocales supportedLocales = element.getAnnotation(SupportedLocales.class);
+    if (nonNull(supportedLocales) && supportedLocales.value().length > 0) {
+      return Arrays.asList(supportedLocales.value());
     }
 
-    @Override
-    public Set<? extends Class<? extends Annotation>> annotations() {
-        return Collections.singleton(IsCustomDateTimeFormat.class);
-    }
+    ProcessorContext context = new ProcessorContext(processingEnv);
+    // Get the current locale and interface type.
+    PropertyOracle propertyOracle = new PropertyOracleImpl();
+    LocaleUtils localeUtils = LocaleUtils.getInstance(messager, propertyOracle, context);
+    GwtLocale gwtLocale = localeUtils.getCompileLocale();
 
-    @Override
-    public Set<Element> process(
-            SetMultimap<Class<? extends Annotation>, Element> elementsByAnnotation) {
+    return Collections.singletonList(gwtLocale.getAsString());
+  }
 
-        for (Element element : elementsByAnnotation.get(IsCustomDateTimeFormat.class)) {
-            try {
-                generateCustomDateTimeFormats((TypeElement) element);
-            } catch (IOException e) {
-                ExceptionUtil.messageStackTrace(messager, e);
-            }
-        }
-
-        return ImmutableSet.of();
-    }
-
-    private void generateCustomDateTimeFormats(TypeElement element)
-            throws IOException {
-
-        TypeElement dateTimeFormat = elements.getTypeElement(DateTimeFormat.class.getName());
-        // TODO(jat): runtime locales support
-        List<String> supportedLocales = getSupportedLocales(element);
-
-        supportedLocales.forEach(locale -> {
-            DateTimePatternGenerator dtpg = getDateTimePatternGenerator(locale);
-            String className = element.getSimpleName().toString().replace('.', '_') + "_"
-                    + locale;
-
-            TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(className)
-                    .addModifiers(Modifier.PUBLIC)
-                    .addSuperinterface(TypeName.get(element.asType()));
-
-            element.getEnclosedElements()
-                    .stream()
-                    .filter(e -> ElementKind.METHOD.equals(e.getKind()))
-                    .map(e -> (ExecutableElement) e)
-                    .forEach(method -> {
-                        TypeMirror returnType = method.getReturnType();
-                        if (!types.isSameType(returnType, dateTimeFormat.asType())) {
-                            messager.printMessage(Diagnostic.Kind.ERROR, element.getQualifiedName() + "." + method.getSimpleName().toString()
-                                    + " must return DateTimeFormat");
-                        }
-                        String pattern;
-                        CustomDateTimeFormat.Pattern annotation = method.getAnnotation(CustomDateTimeFormat.Pattern.class);
-                        if (annotation == null) {
-                            messager.printMessage(Diagnostic.Kind.ERROR, element.getQualifiedName() + "." + method.getSimpleName()
-                                    + " must have an @Pattern annotation");
-                        }
-                        pattern = annotation.value();
-                        pattern = dtpg.getBestPattern(pattern);
-
-                        typeBuilder.addMethod(MethodSpec
-                                .methodBuilder(method.getSimpleName().toString())
-                                .addAnnotation(Override.class)
-                                .addModifiers(Modifier.PUBLIC)
-                                .returns(TypeName.get(method.getReturnType()))
-                                .addStatement("return $T.getFormat(\"$L\")", TypeName.get(method.getReturnType()), pattern)
-                                .build());
-                    });
-
-            JavaFile driverFile = JavaFile.builder(elements.getPackageOf(element).getQualifiedName().toString(), typeBuilder.build()).build();
-
-            try {
-                driverFile.writeTo(filer);
-            } catch (IOException e) {
-                ExceptionUtil.messageStackTrace(messager, e);
-            }
-        } );
-
-
-
-    }
-
-    private List<String> getSupportedLocales(TypeElement element) {
-        SupportedLocales supportedLocales = element.getAnnotation(SupportedLocales.class);
-        if (nonNull(supportedLocales) && supportedLocales.value().length > 0) {
-            return Arrays.asList(supportedLocales.value());
-        }
-
-        ProcessorContext context = new ProcessorContext(processingEnv);
-        // Get the current locale and interface type.
-        PropertyOracle propertyOracle = new PropertyOracleImpl();
-        LocaleUtils localeUtils = LocaleUtils.getInstance(messager, propertyOracle, context);
-        GwtLocale gwtLocale = localeUtils.getCompileLocale();
-
-        return Collections.singletonList(gwtLocale.getAsString());
-    }
-
-    protected DateTimePatternGenerator getDateTimePatternGenerator(String localeName) {
-        return new DateTimePatternGenerator(localeName);
-    }
-
+  protected DateTimePatternGenerator getDateTimePatternGenerator(String localeName) {
+    return new DateTimePatternGenerator(localeName);
+  }
 }

--- a/gwt-datetimeformat-processor/src/main/java/org/gwtproject/i18n/datetimeformat/processor/CustomDateTimeFormatProcessor.java
+++ b/gwt-datetimeformat-processor/src/main/java/org/gwtproject/i18n/datetimeformat/processor/CustomDateTimeFormatProcessor.java
@@ -32,8 +32,6 @@ public class CustomDateTimeFormatProcessor extends BasicAnnotationProcessor {
   @Override
   protected Iterable<? extends ProcessingStep> initSteps() {
     return ImmutableList.of(
-        new CustomDateTimeFormatProcessingStep.Builder()
-            .setProcessingEnv(processingEnv)
-            .build());
+        new CustomDateTimeFormatProcessingStep.Builder().setProcessingEnv(processingEnv).build());
   }
 }

--- a/gwt-datetimeformat-processor/src/main/java/org/gwtproject/i18n/datetimeformat/processor/DateTimePatternGenerator.java
+++ b/gwt-datetimeformat-processor/src/main/java/org/gwtproject/i18n/datetimeformat/processor/DateTimePatternGenerator.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -17,10 +17,7 @@ package org.gwtproject.i18n.datetimeformat.processor;
 
 import com.ibm.icu.util.ULocale;
 
-/**
- * Helper class to create a localized date/time pattern based on a pattern
- * skeleton.
- */
+/** Helper class to create a localized date/time pattern based on a pattern skeleton. */
 public class DateTimePatternGenerator {
   // TODO(jat): Currently uses ICU4J's DateTimePatternGenerator, but should
   // probably be rewritten to avoid that dependency.
@@ -29,7 +26,7 @@ public class DateTimePatternGenerator {
 
   /**
    * Construct a DateTimePatternGenerator for a given locale.
-   * 
+   *
    * @param localeName
    */
   public DateTimePatternGenerator(String localeName) {
@@ -39,13 +36,12 @@ public class DateTimePatternGenerator {
   }
 
   /**
-   * Get the best matching localized pattern for the requested skeleton
-   * pattern.
-   * 
-   * @param skeleton a skeleton pattern consisting of groups of pattern
-   *     characters - spaces and punctuation are ignored
-   * @return a localized pattern suitable for use with
-   *     {@link org.gwtproject.i18n.client.DateTimeFormat}.
+   * Get the best matching localized pattern for the requested skeleton pattern.
+   *
+   * @param skeleton a skeleton pattern consisting of groups of pattern characters - spaces and
+   *     punctuation are ignored
+   * @return a localized pattern suitable for use with {@link
+   *     org.gwtproject.i18n.client.DateTimeFormat}.
    */
   public String getBestPattern(String skeleton) {
     return dtpg.getBestPattern(skeleton);

--- a/gwt-datetimeformat-processor/src/test/java/org/gwtproject/i18n/datetimeformat/DateTimeFormat_de_Test.java
+++ b/gwt-datetimeformat-processor/src/test/java/org/gwtproject/i18n/datetimeformat/DateTimeFormat_de_Test.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -15,18 +15,14 @@
  */
 package org.gwtproject.i18n.datetimeformat;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
 import org.gwtproject.i18n.client.DateTimeFormat;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Date;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-/**
- * Tests formatting functionality in {@link DateTimeFormat} for the German
- * language.
- */
+/** Tests formatting functionality in {@link DateTimeFormat} for the German language. */
 @SuppressWarnings("deprecation")
 public class DateTimeFormat_de_Test {
 
@@ -43,5 +39,4 @@ public class DateTimeFormat_de_Test {
     assertThat("15. Februar 2010").isEqualTo(m.yearMonthDayFull().format(d));
     assertThat("15. Februar 2010").isEqualTo(m.yearMonthDayFull2().format(d));
   }
-
 }

--- a/gwt-datetimeformat-processor/src/test/java/org/gwtproject/i18n/datetimeformat/DateTimeFormat_en_Test.java
+++ b/gwt-datetimeformat-processor/src/test/java/org/gwtproject/i18n/datetimeformat/DateTimeFormat_en_Test.java
@@ -15,13 +15,11 @@
  */
 package org.gwtproject.i18n.datetimeformat;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.Date;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Date;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Tests formatting functionality in {@link org.gwtproject.i18n.shared.DateTimeFormat} for the
@@ -29,17 +27,17 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class DateTimeFormat_en_Test {
 
-    @Before
-    public void setUp() throws Exception {
-        System.setProperty("locale", "en");
-    }
+  @Before
+  public void setUp() throws Exception {
+    System.setProperty("locale", "en");
+  }
 
-    @Test
-    public void testCustomFormats() {
-        MyFormats m = new MyFormats_en();
-        Date d = new Date(2010 - 1900, 1, 15, 12, 0, 0);
-        assertThat("Feb 15, 2010").isEqualTo(m.yearMonthDayAbbrev().format(d));
-        assertThat("February 15, 2010").isEqualTo(m.yearMonthDayFull().format(d));
-        assertThat("February 15, 2010").isEqualTo(m.yearMonthDayFull2().format(d));
-    }
+  @Test
+  public void testCustomFormats() {
+    MyFormats m = new MyFormats_en();
+    Date d = new Date(2010 - 1900, 1, 15, 12, 0, 0);
+    assertThat("Feb 15, 2010").isEqualTo(m.yearMonthDayAbbrev().format(d));
+    assertThat("February 15, 2010").isEqualTo(m.yearMonthDayFull().format(d));
+    assertThat("February 15, 2010").isEqualTo(m.yearMonthDayFull2().format(d));
+  }
 }

--- a/gwt-datetimeformat-processor/src/test/java/org/gwtproject/i18n/datetimeformat/MyFormats.java
+++ b/gwt-datetimeformat-processor/src/test/java/org/gwtproject/i18n/datetimeformat/MyFormats.java
@@ -1,33 +1,40 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.gwtproject.i18n.datetimeformat;
+
+import static org.gwtproject.i18n.shared.CustomDateTimeFormat.Pattern;
 
 import org.gwtproject.i18n.shared.DateTimeFormat;
 import org.gwtproject.i18n.shared.SupportedLocales;
 import org.gwtproject.i18n.shared.annotations.IsCustomDateTimeFormat;
 
-import static org.gwtproject.i18n.shared.CustomDateTimeFormat.Pattern;
-
-/**
- * Class for getting customized date/time formats.
- */
+/** Class for getting customized date/time formats. */
 @IsCustomDateTimeFormat
 @SupportedLocales({"en", "de"})
 public interface MyFormats {
 
-  /**
-   * Returns a pattern for abbreviated year, month, and date.
-   */
+  /** Returns a pattern for abbreviated year, month, and date. */
   @Pattern("yMMMd")
   DateTimeFormat yearMonthDayAbbrev();
 
-  /**
-   * Returns a pattern for full year, month, and date.
-   */
+  /** Returns a pattern for full year, month, and date. */
   @Pattern("yyyyMMMMd")
   DateTimeFormat yearMonthDayFull();
 
-  /**
-   * Returns a pattern for full year, month, and date.
-   */
+  /** Returns a pattern for full year, month, and date. */
   @Pattern("MMMM d, yyyy")
   DateTimeFormat yearMonthDayFull2();
 }

--- a/gwt-datetimeformat/src/main/java/org/gwtproject/i18n/client/DateTimeFormat.java
+++ b/gwt-datetimeformat/src/main/java/org/gwtproject/i18n/client/DateTimeFormat.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2008 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -15,19 +15,18 @@
  */
 package org.gwtproject.i18n.client;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.gwtproject.i18n.client.impl.cldr.DateTimeFormatInfoImpl_en;
 import org.gwtproject.i18n.shared.CustomDateTimeFormat;
 import org.gwtproject.i18n.shared.DateTimeFormatInfo;
 import org.gwtproject.i18n.shared.impl.cldr.DateTimeFormatInfo_factory;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * Formats and parses dates and times using locale-sensitive patterns.
- * 
+ *
  * <h3>Patterns</h3>
- * 
+ *
  * <table>
  * <tr>
  * <th>Symbol</th>
@@ -35,140 +34,140 @@ import java.util.Map;
  * <th>Presentation</th>
  * <th>Example</th>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>G</code></td>
  * <td>era designator</td>
  * <td>Text</td>
  * <td><code>AD</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>y</code></td>
  * <td>year</td>
  * <td>Number</td>
  * <td><code>1996</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>L</code></td>
  * <td>standalone month in year</td>
  * <td>Text or Number</td>
  * <td><code>July (or) 07</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>M</code></td>
  * <td>month in year</td>
  * <td>Text or Number</td>
  * <td><code>July (or) 07</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>d</code></td>
  * <td>day in month</td>
  * <td>Number</td>
  * <td><code>10</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>h</code></td>
  * <td>hour in am/pm (1-12)</td>
  * <td>Number</td>
  * <td><code>12</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>H</code></td>
  * <td>hour in day (0-23)</td>
  * <td>Number</td>
  * <td><code>0</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>m</code></td>
  * <td>minute in hour</td>
  * <td>Number</td>
  * <td><code>30</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>s</code></td>
  * <td>second in minute</td>
  * <td>Number</td>
  * <td><code>55</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>S</code></td>
  * <td>fractional second</td>
  * <td>Number</td>
  * <td><code>978</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>E</code></td>
  * <td>day of week</td>
  * <td>Text</td>
  * <td><code>Tuesday</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>c</code></td>
  * <td>standalone day of week</td>
  * <td>Text</td>
  * <td><code>Tuesday</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>a</code></td>
  * <td>am/pm marker</td>
  * <td>Text</td>
  * <td><code>PM</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>k</code></td>
  * <td>hour in day (1-24)</td>
  * <td>Number</td>
  * <td><code>24</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>K</code></td>
  * <td>hour in am/pm (0-11)</td>
  * <td>Number</td>
  * <td><code>0</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>z</code></td>
  * <td>time zone</td>
  * <td>Text</td>
  * <td><code>Pacific Standard Time(see comment)</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>Z</code></td>
  * <td>time zone (RFC 822)</td>
  * <td>Text</td>
  * <td><code>-0800(See comment)</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>v</code></td>
  * <td>time zone id</td>
  * <td>Text</td>
  * <td><code>America/Los_Angeles(See comment)</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>'</code></td>
  * <td>escape for text</td>
  * <td>Delimiter</td>
  * <td><code>'Date='</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>''</code></td>
  * <td>single quote</td>
@@ -176,58 +175,46 @@ import java.util.Map;
  * <td><code>'o''clock'</code></td>
  * </tr>
  * </table>
- * 
- * <p>
- * The number of pattern letters influences the format, as follows:
- * </p>
- * 
+ *
+ * <p>The number of pattern letters influences the format, as follows:
+ *
  * <dl>
- * <dt>Text</dt>
- * <dd>if 4 or more, then use the full form; if less than 4, use short or
- * abbreviated form if it exists (e.g., <code>"EEEE"</code> produces
- * <code>"Monday"</code>, <code>"EEE"</code> produces <code>"Mon"</code>)</dd>
- * 
- * <dt>Number</dt>
- * <dd>the minimum number of digits. Shorter numbers are zero-padded to this
- * amount (e.g. if <code>"m"</code> produces <code>"6"</code>, <code>"mm"</code>
- * produces <code>"06"</code>). Year is handled specially; that is, if the count
- * of 'y' is 2, the Year will be truncated to 2 digits. (e.g., if
- * <code>"yyyy"</code> produces <code>"1997"</code>, <code>"yy"</code> produces
- * <code>"97"</code>.) Unlike other fields, fractional seconds are padded on the
- * right with zero.</dd>
- * 
- * <dt>Text or Number</dt>
- * <dd>3 or more, use text, otherwise use number. (e.g. <code>"M"</code>
- * produces <code>"1"</code>, <code>"MM"</code> produces <code>"01"</code>,
- * <code>"MMM"</code> produces <code>"Jan"</code>, and <code>"MMMM"</code>
- * produces <code>"January"</code>.  Some pattern letters also treat a count
- * of 5 specially, meaning a single-letter abbreviation: <code>L</code>,
- * <code>M</code>, <code>E</code>, and <code>c</code>.</dd>
+ *   <dt>Text
+ *   <dd>if 4 or more, then use the full form; if less than 4, use short or abbreviated form if it
+ *       exists (e.g., <code>"EEEE"</code> produces <code>"Monday"</code>, <code>"EEE"</code>
+ *       produces <code>"Mon"</code>)
+ *   <dt>Number
+ *   <dd>the minimum number of digits. Shorter numbers are zero-padded to this amount (e.g. if
+ *       <code>"m"</code> produces <code>"6"</code>, <code>"mm"</code> produces <code>"06"</code>).
+ *       Year is handled specially; that is, if the count of 'y' is 2, the Year will be truncated to
+ *       2 digits. (e.g., if <code>"yyyy"</code> produces <code>"1997"</code>, <code>"yy"</code>
+ *       produces <code>"97"</code>.) Unlike other fields, fractional seconds are padded on the
+ *       right with zero.
+ *   <dt>Text or Number
+ *   <dd>3 or more, use text, otherwise use number. (e.g. <code>"M"</code> produces <code>"1"</code>
+ *       , <code>"MM"</code> produces <code>"01"</code>, <code>"MMM"</code> produces <code>"Jan"
+ *       </code>, and <code>"MMMM"</code> produces <code>"January"</code>. Some pattern letters also
+ *       treat a count of 5 specially, meaning a single-letter abbreviation: <code>L</code>, <code>M
+ *       </code>, <code>E</code>, and <code>c</code>.
  * </dl>
- * 
- * <p>
- * Any characters in the pattern that are not in the ranges of ['<code>a</code>
- * '..'<code>z</code>'] and ['<code>A</code>'..'<code>Z</code>'] will be treated
- * as quoted text. For instance, characters like '<code>:</code>', '
- * <code>.</code>', '<code> </code>' (space), '<code>#</code>' and '
- * <code>@</code>' will appear in the resulting time text even they are not
- * embraced within single quotes.
- * </p>
- * 
- * <p>
- * [Time Zone Handling] Web browsers don't provide all the information we need
- * for proper time zone formating -- so GWT has a copy of the required data, for
- * your convenience. For simpler cases, one can also use a fallback
- * implementation that only keeps track of the current timezone offset. These
- * two approaches are called, respectively, Common TimeZones and Simple
- * TimeZones, although both are implemented with the same TimeZone class.
- * 
- * "TimeZone createTimeZone(String timezoneData)" returns a Common TimeZone
- * object, and "TimeZone createTimeZone(int timeZoneOffsetInMinutes)" returns a
- * Simple TimeZone object. The one provided by OS fall into to Simple TimeZone
- * category. For formatting purpose, following table shows the behavior of GWT
- * DateTimeFormat.
- * </p>
+ *
+ * <p>Any characters in the pattern that are not in the ranges of ['<code>a</code> '..'<code>z
+ * </code>'] and ['<code>A</code>'..'<code>Z</code>'] will be treated as quoted text. For instance,
+ * characters like '<code>:</code>', ' <code>.</code>', '<code> </code>' (space), '<code>#</code>'
+ * and ' <code>@</code>' will appear in the resulting time text even they are not embraced within
+ * single quotes.
+ *
+ * <p>[Time Zone Handling] Web browsers don't provide all the information we need for proper time
+ * zone formating -- so GWT has a copy of the required data, for your convenience. For simpler
+ * cases, one can also use a fallback implementation that only keeps track of the current timezone
+ * offset. These two approaches are called, respectively, Common TimeZones and Simple TimeZones,
+ * although both are implemented with the same TimeZone class.
+ *
+ * <p>"TimeZone createTimeZone(String timezoneData)" returns a Common TimeZone object, and "TimeZone
+ * createTimeZone(int timeZoneOffsetInMinutes)" returns a Simple TimeZone object. The one provided
+ * by OS fall into to Simple TimeZone category. For formatting purpose, following table shows the
+ * behavior of GWT DateTimeFormat.
+ *
  * <table>
  * <tr>
  * <th>Pattern</th>
@@ -265,126 +252,108 @@ import java.util.Map;
  * <td>Etc/GMT+7</td>
  * </tr>
  * </table>
- * 
+ *
  * <h3>Parsing Dates and Times</h3>
- * <p>
- * The pattern does not need to specify every field.  If the year, month, or
- * day is missing from the pattern, the corresponding value will be taken from
- * the current date.  If the month is specified but the day is not, the day will
- * be constrained to the last day within the specified month.  If the hour,
- * minute, or second is missing, the value defaults to zero.
- * </p>
- * 
- * <p>
- * As with formatting (described above), the count of pattern letters determines
- * the parsing behavior.
- * </p>
- * 
+ *
+ * <p>The pattern does not need to specify every field. If the year, month, or day is missing from
+ * the pattern, the corresponding value will be taken from the current date. If the month is
+ * specified but the day is not, the day will be constrained to the last day within the specified
+ * month. If the hour, minute, or second is missing, the value defaults to zero.
+ *
+ * <p>As with formatting (described above), the count of pattern letters determines the parsing
+ * behavior.
+ *
  * <dl>
- * <dt>Text</dt>
- * <dd>4 or more pattern letters--use full form, less than 4--use short or
- * abbreviated form if one exists. In parsing, we will always try long format,
- * then short.</dd>
- * 
- * <dt>Number</dt>
- * <dd>the minimum number of digits.</dd>
- * 
- * <dt>Text or Number</dt>
- * <dd>3 or more characters means use text, otherwise use number</dd>
+ *   <dt>Text
+ *   <dd>4 or more pattern letters--use full form, less than 4--use short or abbreviated form if one
+ *       exists. In parsing, we will always try long format, then short.
+ *   <dt>Number
+ *   <dd>the minimum number of digits.
+ *   <dt>Text or Number
+ *   <dd>3 or more characters means use text, otherwise use number
  * </dl>
- * 
- * <p>
- * Although the current pattern specification doesn't not specify behavior for
- * all letters, it may in the future. It is strongly discouraged to use
- * unspecified letters as literal text without quoting them.
- * </p>
- * <p>
- * [Note on TimeZone] The time zone support for parsing is limited. Only
- * standard GMT and RFC format are supported. Time zone specification using time
- * zone id (like America/Los_Angeles), time zone names (like PST, Pacific
- * Standard Time) are not supported. Normally, it is too much a burden for a
- * client application to load all the time zone symbols. And in almost all those
- * cases, it is a better choice to do such parsing on server side through
- * certain RPC mechanism. This decision is based on particular use cases we have
- * studied; in principle, it could be changed in future versions.
- * </p>
- * 
+ *
+ * <p>Although the current pattern specification doesn't not specify behavior for all letters, it
+ * may in the future. It is strongly discouraged to use unspecified letters as literal text without
+ * quoting them.
+ *
+ * <p>[Note on TimeZone] The time zone support for parsing is limited. Only standard GMT and RFC
+ * format are supported. Time zone specification using time zone id (like America/Los_Angeles), time
+ * zone names (like PST, Pacific Standard Time) are not supported. Normally, it is too much a burden
+ * for a client application to load all the time zone symbols. And in almost all those cases, it is
+ * a better choice to do such parsing on server side through certain RPC mechanism. This decision is
+ * based on particular use cases we have studied; in principle, it could be changed in future
+ * versions.
+ *
  * <h3>Examples</h3>
+ *
  * <table>
  * <tr>
  * <th>Pattern</th>
  * <th>Formatted Text</th>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>"yyyy.MM.dd G 'at' HH:mm:ss vvvv"</code></td>
  * <td><code>1996.07.10 AD at 15:08:56 America/Los_Angeles</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>"EEE, MMM d, ''yy"</code></td>
  * <td><code>Wed, July 10, '96</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>"h:mm a"</code></td>
  * <td><code>12:08 PM</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>"hh 'o''clock' a, zzzz"</code></td>
  * <td><code> 12 o'clock PM, Pacific Daylight Time</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>"K:mm a, vvvv"</code></td>
  * <td><code> 0:00 PM, America/Los_Angeles</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>"yyyyy.MMMMM.dd GGG hh:mm aaa"</code></td>
  * <td><code>01996.July.10 AD 12:08 PM</code></td>
  * </tr>
  * </table>
- * 
- * <h3>Additional Parsing Considerations</h3>
- * <p>
- * When parsing a date string using the abbreviated year pattern (
- * <code>"yy"</code>), the parser must interpret the abbreviated year relative
- * to some century. It does this by adjusting dates to be within 80 years before
- * and 20 years after the time the parser instance is created. For example,
- * using a pattern of <code>"MM/dd/yy"</code> and a <code>DateTimeFormat</code>
- * object created on Jan 1, 1997, the string <code>"01/11/12"</code> would be
- * interpreted as Jan 11, 2012 while the string <code>"05/04/64"</code> would be
- * interpreted as May 4, 1964. During parsing, only strings consisting of
- * exactly two digits, as defined by {@link Character#isDigit(char)},
- * will be parsed into the default century. If the year pattern does not have
- * exactly two 'y' characters, the year is interpreted literally, regardless of
- * the number of digits. For example, using the pattern
- * <code>"MM/dd/yyyy"</code>, "01/11/12" parses to Jan 11, 12 A.D.
- * </p>
- * 
- * <p>
- * When numeric fields abut one another directly, with no intervening delimiter
- * characters, they constitute a run of abutting numeric fields. Such runs are
- * parsed specially. For example, the format "HHmmss" parses the input text
- * "123456" to 12:34:56, parses the input text "12345" to 1:23:45, and fails to
- * parse "1234". In other words, the leftmost field of the run is flexible,
- * while the others keep a fixed width. If the parse fails anywhere in the run,
- * then the leftmost field is shortened by one character, and the entire run is
- * parsed again. This is repeated until either the parse succeeds or the
- * leftmost field is one character in length. If the parse still fails at that
- * point, the parse of the run fails.
- * </p>
- * 
- * <p>
- * In the current implementation, timezone parsing only supports
- * <code>GMT:hhmm</code>, <code>GMT:+hhmm</code>, and <code>GMT:-hhmm</code>.
- * </p>
- * 
- * <h3>Example</h3> {@example com.google.gwt.examples.DateTimeFormatExample}
  *
- * deprecated use {@link org.gwtproject.i18n.shared.DateTimeFormat} instead
+ * <h3>Additional Parsing Considerations</h3>
+ *
+ * <p>When parsing a date string using the abbreviated year pattern ( <code>"yy"</code>), the parser
+ * must interpret the abbreviated year relative to some century. It does this by adjusting dates to
+ * be within 80 years before and 20 years after the time the parser instance is created. For
+ * example, using a pattern of <code>"MM/dd/yy"</code> and a <code>DateTimeFormat</code> object
+ * created on Jan 1, 1997, the string <code>"01/11/12"</code> would be interpreted as Jan 11, 2012
+ * while the string <code>"05/04/64"</code> would be interpreted as May 4, 1964. During parsing,
+ * only strings consisting of exactly two digits, as defined by {@link Character#isDigit(char)},
+ * will be parsed into the default century. If the year pattern does not have exactly two 'y'
+ * characters, the year is interpreted literally, regardless of the number of digits. For example,
+ * using the pattern <code>"MM/dd/yyyy"</code>, "01/11/12" parses to Jan 11, 12 A.D.
+ *
+ * <p>When numeric fields abut one another directly, with no intervening delimiter characters, they
+ * constitute a run of abutting numeric fields. Such runs are parsed specially. For example, the
+ * format "HHmmss" parses the input text "123456" to 12:34:56, parses the input text "12345" to
+ * 1:23:45, and fails to parse "1234". In other words, the leftmost field of the run is flexible,
+ * while the others keep a fixed width. If the parse fails anywhere in the run, then the leftmost
+ * field is shortened by one character, and the entire run is parsed again. This is repeated until
+ * either the parse succeeds or the leftmost field is one character in length. If the parse still
+ * fails at that point, the parse of the run fails.
+ *
+ * <p>In the current implementation, timezone parsing only supports <code>GMT:hhmm</code>, <code>
+ * GMT:+hhmm</code>, and <code>GMT:-hhmm</code>.
+ *
+ * <h3>Example</h3>
+ *
+ * {@example com.google.gwt.examples.DateTimeFormatExample}
+ *
+ * <p>deprecated use {@link org.gwtproject.i18n.shared.DateTimeFormat} instead
  */
 // Temporarily remove deprecation to keep from breaking teams that don't allow
 // deprecated references.
@@ -392,29 +361,34 @@ import java.util.Map;
 public class DateTimeFormat extends org.gwtproject.i18n.shared.DateTimeFormat {
 
   /**
-   * Predefined date/time formats -- see {@link CustomDateTimeFormat} if you
-   * need some format that isn't supplied here.
+   * Predefined date/time formats -- see {@link CustomDateTimeFormat} if you need some format that
+   * isn't supplied here.
    *
-   * deprecated use {@link org.gwtproject.i18n.shared.DateTimeFormat.PredefinedFormat} instead
+   * <p>deprecated use {@link org.gwtproject.i18n.shared.DateTimeFormat.PredefinedFormat} instead
    */
-   // Temporarily remove deprecation to keep from breaking teams that don't allow
-   // deprecated references.
-   // @Deprecated
+  // Temporarily remove deprecation to keep from breaking teams that don't allow
+  // deprecated references.
+  // @Deprecated
   public enum PredefinedFormat {
 
     // TODO(jat): Javadoc to explain these formats
 
     /**
      * ISO 8601 date format, fixed across all locales.
+     *
      * <p>Example: {@code 2008-10-03T10:29:40.046-04:00}
+     *
      * <p>http://code.google.com/p/google-web-toolkit/issues/detail?id=3068
+     *
      * <p>http://www.iso.org/iso/support/faqs/faqs_widely_used_standards/widely_used_standards_other/date_and_time_format.htm
      */
     ISO_8601,
 
     /**
      * RFC 2822 date format, fixed across all locales.
+     *
      * <p>Example: {@code Thu, 20 May 2010 17:54:50 -0700}
+     *
      * <p>http://tools.ietf.org/html/rfc2822#section-3.3
      */
     RFC_2822,
@@ -466,10 +440,9 @@ public class DateTimeFormat extends org.gwtproject.i18n.shared.DateTimeFormat {
 
   /**
    * Get a DateTimeFormat instance for a predefined format.
-   * 
-   * <p>See {@link CustomDateTimeFormat} if you need a localized format that is
-   * not supported here.
-   * 
+   *
+   * <p>See {@link CustomDateTimeFormat} if you need a localized format that is not supported here.
+   *
    * @param predef {@link PredefinedFormat} describing desired format
    * @return a DateTimeFormat instance for the specified format
    */
@@ -504,20 +477,16 @@ public class DateTimeFormat extends org.gwtproject.i18n.shared.DateTimeFormat {
         pattern = dtfi.dateFormatShort();
         break;
       case DATE_TIME_FULL:
-        pattern = dtfi.dateTimeFull(dtfi.timeFormatFull(),
-            dtfi.dateFormatFull());
+        pattern = dtfi.dateTimeFull(dtfi.timeFormatFull(), dtfi.dateFormatFull());
         break;
       case DATE_TIME_LONG:
-        pattern = dtfi.dateTimeLong(dtfi.timeFormatLong(),
-            dtfi.dateFormatLong());
+        pattern = dtfi.dateTimeLong(dtfi.timeFormatLong(), dtfi.dateFormatLong());
         break;
       case DATE_TIME_MEDIUM:
-        pattern = dtfi.dateTimeMedium(dtfi.timeFormatMedium(),
-            dtfi.dateFormatMedium());
+        pattern = dtfi.dateTimeMedium(dtfi.timeFormatMedium(), dtfi.dateFormatMedium());
         break;
       case DATE_TIME_SHORT:
-        pattern = dtfi.dateTimeShort(dtfi.timeFormatShort(),
-            dtfi.dateFormatShort());
+        pattern = dtfi.dateTimeShort(dtfi.timeFormatShort(), dtfi.dateFormatShort());
         break;
       case DAY:
         pattern = dtfi.formatDay();
@@ -598,43 +567,37 @@ public class DateTimeFormat extends org.gwtproject.i18n.shared.DateTimeFormat {
         pattern = dtfi.formatYearQuarterShort();
         break;
       default:
-        throw new IllegalArgumentException("Unexpected predefined format "
-            + predef);
+        throw new IllegalArgumentException("Unexpected predefined format " + predef);
     }
     return getFormat(pattern, dtfi);
   }
 
   /**
-   * Returns a DateTimeFormat object using the specified pattern. If you need to
-   * format or parse repeatedly using the same pattern, it is highly recommended
-   * that you cache the returned <code>DateTimeFormat</code> object and reuse it
-   * rather than calling this method repeatedly.
-   * 
-   * <p>Note that the pattern supplied is used as-is -- for example, if you
-   * supply "MM/dd/yyyy" as the pattern, that is the order you will get the
-   * fields, even in locales where the order is different.  It is recommended to
-   * use {@link #getFormat(PredefinedFormat)} instead -- if you use this method,
-   * you are taking responsibility for localizing the patterns yourself.
-   * 
+   * Returns a DateTimeFormat object using the specified pattern. If you need to format or parse
+   * repeatedly using the same pattern, it is highly recommended that you cache the returned <code>
+   * DateTimeFormat</code> object and reuse it rather than calling this method repeatedly.
+   *
+   * <p>Note that the pattern supplied is used as-is -- for example, if you supply "MM/dd/yyyy" as
+   * the pattern, that is the order you will get the fields, even in locales where the order is
+   * different. It is recommended to use {@link #getFormat(PredefinedFormat)} instead -- if you use
+   * this method, you are taking responsibility for localizing the patterns yourself.
+   *
    * @param pattern string to specify how the date should be formatted
-   * 
-   * @return a <code>DateTimeFormat</code> object that can be used for format or
-   *         parse date/time values matching the specified pattern
-   * 
-   * @throws IllegalArgumentException if the specified pattern could not be
-   *           parsed
+   * @return a <code>DateTimeFormat</code> object that can be used for format or parse date/time
+   *     values matching the specified pattern
+   * @throws IllegalArgumentException if the specified pattern could not be parsed
    */
   public static DateTimeFormat getFormat(String pattern) {
     return getFormat(pattern, getDefaultDateTimeFormatInfo());
   }
 
   /**
-   * Retrieve the DateTimeFormat object for full date format. The pattern for
-   * this format is predefined for each locale.
-   * 
+   * Retrieve the DateTimeFormat object for full date format. The pattern for this format is
+   * predefined for each locale.
+   *
    * @return A DateTimeFormat object
-   * @deprecated use {@link #getFormat(PredefinedFormat)} with
-   *     {@link PredefinedFormat#DATE_FULL} instead
+   * @deprecated use {@link #getFormat(PredefinedFormat)} with {@link PredefinedFormat#DATE_FULL}
+   *     instead
    */
   @Deprecated
   public static DateTimeFormat getFullDateFormat() {
@@ -642,12 +605,12 @@ public class DateTimeFormat extends org.gwtproject.i18n.shared.DateTimeFormat {
   }
 
   /**
-   * Retrieve the DateTimeFormat object for full date and time format. The
-   * pattern for this format is predefined for each locale.
-   * 
+   * Retrieve the DateTimeFormat object for full date and time format. The pattern for this format
+   * is predefined for each locale.
+   *
    * @return A DateTimeFormat object
-   * @deprecated use {@link #getFormat(PredefinedFormat)} with
-   *     {@link PredefinedFormat#DATE_TIME_FULL} instead
+   * @deprecated use {@link #getFormat(PredefinedFormat)} with {@link
+   *     PredefinedFormat#DATE_TIME_FULL} instead
    */
   @Deprecated
   public static DateTimeFormat getFullDateTimeFormat() {
@@ -655,12 +618,12 @@ public class DateTimeFormat extends org.gwtproject.i18n.shared.DateTimeFormat {
   }
 
   /**
-   * Retrieve the DateTimeFormat object for full time format. The pattern for
-   * this format is predefined for each locale.
-   * 
+   * Retrieve the DateTimeFormat object for full time format. The pattern for this format is
+   * predefined for each locale.
+   *
    * @return A DateTimeFormat object
-   * @deprecated use {@link #getFormat(PredefinedFormat)} with
-   *     {@link PredefinedFormat#TIME_FULL} instead
+   * @deprecated use {@link #getFormat(PredefinedFormat)} with {@link PredefinedFormat#TIME_FULL}
+   *     instead
    */
   @Deprecated
   public static DateTimeFormat getFullTimeFormat() {
@@ -668,12 +631,12 @@ public class DateTimeFormat extends org.gwtproject.i18n.shared.DateTimeFormat {
   }
 
   /**
-   * Retrieve the DateTimeFormat object for long date format. The pattern for
-   * this format is predefined for each locale.
-   * 
+   * Retrieve the DateTimeFormat object for long date format. The pattern for this format is
+   * predefined for each locale.
+   *
    * @return A DateTimeFormat object
-   * @deprecated use {@link #getFormat(PredefinedFormat)} with
-   *     {@link PredefinedFormat#DATE_LONG} instead
+   * @deprecated use {@link #getFormat(PredefinedFormat)} with {@link PredefinedFormat#DATE_LONG}
+   *     instead
    */
   @Deprecated
   public static DateTimeFormat getLongDateFormat() {
@@ -681,12 +644,12 @@ public class DateTimeFormat extends org.gwtproject.i18n.shared.DateTimeFormat {
   }
 
   /**
-   * Retrieve the DateTimeFormat object for long date and time format. The
-   * pattern for this format is predefined for each locale.
-   * 
+   * Retrieve the DateTimeFormat object for long date and time format. The pattern for this format
+   * is predefined for each locale.
+   *
    * @return A DateTimeFormat object
-   * @deprecated use {@link #getFormat(PredefinedFormat)} with
-   *     {@link PredefinedFormat#DATE_TIME_LONG} instead
+   * @deprecated use {@link #getFormat(PredefinedFormat)} with {@link
+   *     PredefinedFormat#DATE_TIME_LONG} instead
    */
   @Deprecated
   public static DateTimeFormat getLongDateTimeFormat() {
@@ -694,12 +657,12 @@ public class DateTimeFormat extends org.gwtproject.i18n.shared.DateTimeFormat {
   }
 
   /**
-   * Retrieve the DateTimeFormat object for long time format. The pattern for
-   * this format is predefined for each locale.
-   * 
+   * Retrieve the DateTimeFormat object for long time format. The pattern for this format is
+   * predefined for each locale.
+   *
    * @return A DateTimeFormat object
-   * @deprecated use {@link #getFormat(PredefinedFormat)} with
-   *     {@link PredefinedFormat#TIME_LONG} instead
+   * @deprecated use {@link #getFormat(PredefinedFormat)} with {@link PredefinedFormat#TIME_LONG}
+   *     instead
    */
   @Deprecated
   public static DateTimeFormat getLongTimeFormat() {
@@ -707,12 +670,12 @@ public class DateTimeFormat extends org.gwtproject.i18n.shared.DateTimeFormat {
   }
 
   /**
-   * Retrieve the DateTimeFormat object for medium date format. The pattern for
-   * this format is predefined for each locale.
-   * 
+   * Retrieve the DateTimeFormat object for medium date format. The pattern for this format is
+   * predefined for each locale.
+   *
    * @return A DateTimeFormat object
-   * @deprecated use {@link #getFormat(PredefinedFormat)} with
-   *     {@link PredefinedFormat#DATE_MEDIUM} instead
+   * @deprecated use {@link #getFormat(PredefinedFormat)} with {@link PredefinedFormat#DATE_MEDIUM}
+   *     instead
    */
   @Deprecated
   public static DateTimeFormat getMediumDateFormat() {
@@ -720,12 +683,12 @@ public class DateTimeFormat extends org.gwtproject.i18n.shared.DateTimeFormat {
   }
 
   /**
-   * Retrieve the DateTimeFormat object for medium date and time format. The
-   * pattern for this format is predefined for each locale.
-   * 
+   * Retrieve the DateTimeFormat object for medium date and time format. The pattern for this format
+   * is predefined for each locale.
+   *
    * @return A DateTimeFormat object
-   * @deprecated use {@link #getFormat(PredefinedFormat)} with
-   *     {@link PredefinedFormat#DATE_TIME_MEDIUM} instead
+   * @deprecated use {@link #getFormat(PredefinedFormat)} with {@link
+   *     PredefinedFormat#DATE_TIME_MEDIUM} instead
    */
   @Deprecated
   public static DateTimeFormat getMediumDateTimeFormat() {
@@ -733,12 +696,12 @@ public class DateTimeFormat extends org.gwtproject.i18n.shared.DateTimeFormat {
   }
 
   /**
-   * Retrieve the DateTimeFormat object for medium time format. The pattern for
-   * this format is predefined for each locale.
-   * 
+   * Retrieve the DateTimeFormat object for medium time format. The pattern for this format is
+   * predefined for each locale.
+   *
    * @return A DateTimeFormat object
-   * @deprecated use {@link #getFormat(PredefinedFormat)} with
-   *     {@link PredefinedFormat#TIME_MEDIUM} instead
+   * @deprecated use {@link #getFormat(PredefinedFormat)} with {@link PredefinedFormat#TIME_MEDIUM}
+   *     instead
    */
   @Deprecated
   public static DateTimeFormat getMediumTimeFormat() {
@@ -746,12 +709,12 @@ public class DateTimeFormat extends org.gwtproject.i18n.shared.DateTimeFormat {
   }
 
   /**
-   * Retrieve the DateTimeFormat object for short date format. The pattern for
-   * this format is predefined for each locale.
-   * 
+   * Retrieve the DateTimeFormat object for short date format. The pattern for this format is
+   * predefined for each locale.
+   *
    * @return A DateTimeFormat object
-   * @deprecated use {@link #getFormat(PredefinedFormat)} with
-   *     {@link PredefinedFormat#DATE_SHORT} instead
+   * @deprecated use {@link #getFormat(PredefinedFormat)} with {@link PredefinedFormat#DATE_SHORT}
+   *     instead
    */
   @Deprecated
   public static DateTimeFormat getShortDateFormat() {
@@ -759,12 +722,12 @@ public class DateTimeFormat extends org.gwtproject.i18n.shared.DateTimeFormat {
   }
 
   /**
-   * Retrieve the DateTimeFormat object for short date and time format. The
-   * pattern for this format is predefined for each locale.
-   * 
+   * Retrieve the DateTimeFormat object for short date and time format. The pattern for this format
+   * is predefined for each locale.
+   *
    * @return A DateTimeFormat object
-   * @deprecated use {@link #getFormat(PredefinedFormat)} with
-   *     {@link PredefinedFormat#DATE_TIME_SHORT} instead
+   * @deprecated use {@link #getFormat(PredefinedFormat)} with {@link
+   *     PredefinedFormat#DATE_TIME_SHORT} instead
    */
   @Deprecated
   public static DateTimeFormat getShortDateTimeFormat() {
@@ -772,12 +735,12 @@ public class DateTimeFormat extends org.gwtproject.i18n.shared.DateTimeFormat {
   }
 
   /**
-   * Retrieve the DateTimeFormat object for short time format. The pattern for
-   * this format is predefined for each locale.
-   * 
+   * Retrieve the DateTimeFormat object for short time format. The pattern for this format is
+   * predefined for each locale.
+   *
    * @return A DateTimeFormat object.
-   * @deprecated use {@link #getFormat(PredefinedFormat)} with
-   *     {@link PredefinedFormat#TIME_SHORT} instead
+   * @deprecated use {@link #getFormat(PredefinedFormat)} with {@link PredefinedFormat#TIME_SHORT}
+   *     instead
    */
   @Deprecated
   public static DateTimeFormat getShortTimeFormat() {
@@ -786,13 +749,12 @@ public class DateTimeFormat extends org.gwtproject.i18n.shared.DateTimeFormat {
 
   /**
    * Internal factory method that provides caching.
-   * 
+   *
    * @param pattern
    * @param dtfi
    * @return DateTimeFormat instance
    */
-  protected static DateTimeFormat getFormat(String pattern,
-                                            DateTimeFormatInfo dtfi) {
+  protected static DateTimeFormat getFormat(String pattern, DateTimeFormatInfo dtfi) {
     DateTimeFormatInfo defaultDtfi = getDefaultDateTimeFormatInfo();
     DateTimeFormat dtf = null;
     if (dtfi == defaultDtfi) {
@@ -812,10 +774,12 @@ public class DateTimeFormat extends org.gwtproject.i18n.shared.DateTimeFormat {
   }
 
   /**
-   * Returns true if the predefined format is one that specifies always using
-   * English names/separators.
-   * <p>This should be a method on PredefinedFormat, but that would defeat the
-   * enum optimizations GWT is currently capable of.
+   * Returns true if the predefined format is one that specifies always using English
+   * names/separators.
+   *
+   * <p>This should be a method on PredefinedFormat, but that would defeat the enum optimizations
+   * GWT is currently capable of.
+   *
    * @param predef
    * @return true if the specified format requires English names/separators
    */
@@ -831,9 +795,9 @@ public class DateTimeFormat extends org.gwtproject.i18n.shared.DateTimeFormat {
   }
 
   /**
-   * Constructs a format object using the specified pattern and the date time
-   * constants for the default locale.
-   * 
+   * Constructs a format object using the specified pattern and the date time constants for the
+   * default locale.
+   *
    * @param pattern string pattern specification
    */
   protected DateTimeFormat(String pattern) {
@@ -841,9 +805,8 @@ public class DateTimeFormat extends org.gwtproject.i18n.shared.DateTimeFormat {
   }
 
   /**
-   * Constructs a format object using the specified pattern and user-supplied
-   * date time constants.
-   * 
+   * Constructs a format object using the specified pattern and user-supplied date time constants.
+   *
    * @param pattern string pattern specification
    * @param dtfi DateTimeFormatInfo instance to use
    */

--- a/gwt-datetimeformat/src/main/java/org/gwtproject/i18n/client/TimeZone.java
+++ b/gwt-datetimeformat/src/main/java/org/gwtproject/i18n/client/TimeZone.java
@@ -16,22 +16,18 @@
 package org.gwtproject.i18n.client;
 
 import elemental2.core.JsArray;
-
 import java.util.Date;
 
 /**
- * The TimeZone class implements a time zone information source for client
- * applications. The time zone object is instantiated from a TimeZoneData object,
- * which is made from a JSON string that contains all the data needed for
- * the specified time zone. Applications can instantiate a time zone statically,
- * in which case the data could be retrieved from
- * the {@link org.gwtproject.i18n.client.constants.TimeZoneConstants TimeZoneConstants}
- * class. Applications can also choose to instantiate from a string obtained
- * from a server. The time zone string contains locale specific data. If the
- * application only uses a short representation, the English data will usually
- * satisfy the user's need. In the case that only the time zone offset is known,
- * there is a decent fallback that only uses the time zone offset to create a
- * TimeZone object.
+ * The TimeZone class implements a time zone information source for client applications. The time
+ * zone object is instantiated from a TimeZoneData object, which is made from a JSON string that
+ * contains all the data needed for the specified time zone. Applications can instantiate a time
+ * zone statically, in which case the data could be retrieved from the {@link
+ * org.gwtproject.i18n.client.constants.TimeZoneConstants TimeZoneConstants} class. Applications can
+ * also choose to instantiate from a string obtained from a server. The time zone string contains
+ * locale specific data. If the application only uses a short representation, the English data will
+ * usually satisfy the user's need. In the case that only the time zone offset is known, there is a
+ * decent fallback that only uses the time zone offset to create a TimeZone object.
  */
 public class TimeZone implements org.gwtproject.i18n.shared.TimeZone {
   // constants to reference time zone names in the time zone names array
@@ -41,8 +37,8 @@ public class TimeZone implements org.gwtproject.i18n.shared.TimeZone {
   private static final int DLT_LONG_NAME = 3;
 
   /**
-   * This factory method provides a decent fallback to create a time zone object
-   * just based on a given time zone offset.
+   * This factory method provides a decent fallback to create a time zone object just based on a
+   * given time zone offset.
    *
    * @param timeZoneOffsetInMinutes time zone offset in minutes
    * @return a new time zone object
@@ -60,12 +56,12 @@ public class TimeZone implements org.gwtproject.i18n.shared.TimeZone {
   }
 
   /**
-   * This factory method creates a time zone instance from a JSON string that
-   * contains the time zone information for desired time zone. Applications can
-   * get such a string from the TimeZoneConstants class, or it can request the
-   * string from the server. Either way, the application obtains the original
-   * string from the data provided in the TimeZoneConstant.properties file,
-   * which was carefully prepared from CLDR and Olson time zone database.
+   * This factory method creates a time zone instance from a JSON string that contains the time zone
+   * information for desired time zone. Applications can get such a string from the
+   * TimeZoneConstants class, or it can request the string from the server. Either way, the
+   * application obtains the original string from the data provided in the
+   * TimeZoneConstant.properties file, which was carefully prepared from CLDR and Olson time zone
+   * database.
    *
    * @param tzJSON JSON string that contains time zone data
    * @return a new time zone object
@@ -109,8 +105,8 @@ public class TimeZone implements org.gwtproject.i18n.shared.TimeZone {
   }
 
   /**
-   * In GMT representation, +/- has reverse sign of time zone offset.
-   * when offset == 480, it should output GMT-08:00.
+   * In GMT representation, +/- has reverse sign of time zone offset. when offset == 480, it should
+   * output GMT-08:00.
    */
   private static String composeGMTString(int offset) {
     char data[] = {'G', 'M', 'T', '-', '0', '0', ':', '0', '0'};
@@ -125,9 +121,7 @@ public class TimeZone implements org.gwtproject.i18n.shared.TimeZone {
     return new String(data);
   }
 
-  /**
-   * POSIX time zone ID as fallback.
-   */
+  /** POSIX time zone ID as fallback. */
   private static String composePOSIXTimeZoneID(int offset) {
     if (offset == 0) {
       return "Etc/GMT";
@@ -169,10 +163,9 @@ public class TimeZone implements org.gwtproject.i18n.shared.TimeZone {
   private int standardOffset;
   private String[] tzNames;
   private int[] transitionPoints;
-  private int[]  adjustments;
+  private int[] adjustments;
 
-  private TimeZone() {
-  }
+  private TimeZone() {}
 
   /* (non-Javadoc)
    * @see org.gwtproject.i18n.client.TimeZoneIntf#getDaylightAdjustment(java.util.Date)
@@ -184,8 +177,7 @@ public class TimeZone implements org.gwtproject.i18n.shared.TimeZone {
     }
     long timeInHours = date.getTime() / 1000 / 3600;
     int index = 0;
-    while (index < transitionPoints.length &&
-        timeInHours >= transitionPoints[index]) {
+    while (index < transitionPoints.length && timeInHours >= transitionPoints[index]) {
       ++index;
     }
     return (index == 0) ? 0 : adjustments[index - 1];

--- a/gwt-datetimeformat/src/main/java/org/gwtproject/i18n/client/TimeZoneInfo.java
+++ b/gwt-datetimeformat/src/main/java/org/gwtproject/i18n/client/TimeZoneInfo.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2008 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -18,49 +18,51 @@ package org.gwtproject.i18n.client;
 
 import elemental2.core.Global;
 import elemental2.core.JsArray;
-import elemental2.core.JsNumber;
 import jsinterop.base.Any;
 import jsinterop.base.Js;
 import jsinterop.base.JsPropertyMap;
 
 /**
- * A JavaScript Overlay type on top of the JSON data describing everything we
- * need to know about a particular timezone. The relevant strings of JSON can
- * be found in TimeZoneConstants, or versions localized for non-en locales can
- * be downloaded elsewhere. 
+ * A JavaScript Overlay type on top of the JSON data describing everything we need to know about a
+ * particular timezone. The relevant strings of JSON can be found in TimeZoneConstants, or versions
+ * localized for non-en locales can be downloaded elsewhere.
  */
 public class TimeZoneInfo {
 
   private String id;
-  private JsArray<String> names=new JsArray<>();
+  private JsArray<String> names = new JsArray<>();
   private int std_offset;
-  private JsArray<Integer> transitions=new JsArray<>();
+  private JsArray<Integer> transitions = new JsArray<>();
 
   public static TimeZoneInfo buildTimeZoneData(String json) {
-    TimeZoneInfo timeZoneInfo=new TimeZoneInfo();
+    TimeZoneInfo timeZoneInfo = new TimeZoneInfo();
     JsPropertyMap<?> parsed = Js.cast(Global.JSON.parse(json));
-    timeZoneInfo.id=Js.cast(parsed.get("id"));
-    timeZoneInfo.std_offset=Js.cast(parsed.get("std_offset"));
-    timeZoneInfo.names=Js.cast(parsed.get("names"));
-    JsArray<Any> jsTransitions=Js.cast(parsed.get("transitions"));
-    for(int i=0;i<jsTransitions.length;i++){
+    timeZoneInfo.id = Js.cast(parsed.get("id"));
+    timeZoneInfo.std_offset = Js.cast(parsed.get("std_offset"));
+    timeZoneInfo.names = Js.cast(parsed.get("names"));
+    JsArray<Any> jsTransitions = Js.cast(parsed.get("transitions"));
+    for (int i = 0; i < jsTransitions.length; i++) {
       timeZoneInfo.transitions.push(jsTransitions.getAt(i).asInt());
     }
 
     return timeZoneInfo;
   }
-  
-  protected TimeZoneInfo() { }
-  
-  public final String getID() { return this.id; }
+
+  protected TimeZoneInfo() {}
+
+  public final String getID() {
+    return this.id;
+  }
 
   public final JsArray<String> getNames() {
     return this.names;
   }
-  
-  public final int getStandardOffset() { return this.std_offset; }
-  
-  public final  JsArray<Integer> getTransitions() {
+
+  public final int getStandardOffset() {
+    return this.std_offset;
+  }
+
+  public final JsArray<Integer> getTransitions() {
     return this.transitions;
   }
 }

--- a/gwt-datetimeformat/src/main/java/org/gwtproject/i18n/client/constants/TimeZoneConstants.java
+++ b/gwt-datetimeformat/src/main/java/org/gwtproject/i18n/client/constants/TimeZoneConstants.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -19,15 +19,13 @@ package org.gwtproject.i18n.client.constants;
 import org.gwtproject.i18n.client.Constants;
 
 /**
- * TimeZoneConstants encapsulates a collection of time zone data for use with
- * DateTimeFormat services. This class extends GWT's Constants class.
- * The values of the constants are defined in property files named something
- * like "TimeZoneConstants_xx.properties".
- * 
- * Time zone data has only been provided for the "en" locale. Due to the large
- * size of the time zone data for each locale, we recommend that applications
- * retrieve the necessary data (i.e. over RPC) for the user's locale at run
- * time.
+ * TimeZoneConstants encapsulates a collection of time zone data for use with DateTimeFormat
+ * services. This class extends GWT's Constants class. The values of the constants are defined in
+ * property files named something like "TimeZoneConstants_xx.properties".
+ *
+ * <p>Time zone data has only been provided for the "en" locale. Due to the large size of the time
+ * zone data for each locale, we recommend that applications retrieve the necessary data (i.e. over
+ * RPC) for the user's locale at run time.
  */
 public interface TimeZoneConstants extends Constants {
   String africaAbidjan();

--- a/gwt-datetimeformat/src/main/java/org/gwtproject/i18n/shared/CustomDateTimeFormat.java
+++ b/gwt-datetimeformat/src/main/java/org/gwtproject/i18n/shared/CustomDateTimeFormat.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2011 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -16,26 +16,25 @@
 package org.gwtproject.i18n.shared;
 
 /**
- * Create a custom localized date/time format at compile time. All methods on
- * subtypes of this interface must take no parameters and return DateTimeFormat
- * (which will be an initialized instance).
+ * Create a custom localized date/time format at compile time. All methods on subtypes of this
+ * interface must take no parameters and return DateTimeFormat (which will be an initialized
+ * instance).
  */
 public interface CustomDateTimeFormat {
 
   /**
    * Annotation containing the pattern skeleton.
-   * 
-   * <p>The order of pattern characters and any literals don't matter, just
-   * which pattern characters are present and their counts.
+   *
+   * <p>The order of pattern characters and any literals don't matter, just which pattern characters
+   * are present and their counts.
    */
   public @interface Pattern {
 
     /**
-     * The pattern skeleton for which to generate a localized pattern.  Note
-     * that the order of pattern characters don't matter, as the generated
-     * pattern will be derived from a localized pattern that conveys the same
-     * information.
-     * 
+     * The pattern skeleton for which to generate a localized pattern. Note that the order of
+     * pattern characters don't matter, as the generated pattern will be derived from a localized
+     * pattern that conveys the same information.
+     *
      * @return the pattern skeleton
      */
     String value();

--- a/gwt-datetimeformat/src/main/java/org/gwtproject/i18n/shared/DateTimeFormat.java
+++ b/gwt-datetimeformat/src/main/java/org/gwtproject/i18n/shared/DateTimeFormat.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2008 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -15,16 +15,15 @@
  */
 package org.gwtproject.i18n.shared;
 
+import java.util.*;
 import org.gwtproject.i18n.shared.impl.DateRecord;
 import org.gwtproject.i18n.shared.impl.cldr.DateTimeFormatInfo_factory;
 
-import java.util.*;
-
 /**
  * Formats and parses dates and times using locale-sensitive patterns.
- * 
+ *
  * <h3>Patterns</h3>
- * 
+ *
  * <table>
  * <tr>
  * <th>Symbol</th>
@@ -32,140 +31,140 @@ import java.util.*;
  * <th>Presentation</th>
  * <th>Example</th>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>G</code></td>
  * <td>era designator</td>
  * <td>Text</td>
  * <td><code>AD</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>y</code></td>
  * <td>year</td>
  * <td>Number</td>
  * <td><code>1996</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>L</code></td>
  * <td>standalone month in year</td>
  * <td>Text or Number</td>
  * <td><code>July (or) 07</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>M</code></td>
  * <td>month in year</td>
  * <td>Text or Number</td>
  * <td><code>July (or) 07</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>d</code></td>
  * <td>day in month</td>
  * <td>Number</td>
  * <td><code>10</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>h</code></td>
  * <td>hour in am/pm (1-12)</td>
  * <td>Number</td>
  * <td><code>12</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>H</code></td>
  * <td>hour in day (0-23)</td>
  * <td>Number</td>
  * <td><code>0</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>m</code></td>
  * <td>minute in hour</td>
  * <td>Number</td>
  * <td><code>30</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>s</code></td>
  * <td>second in minute</td>
  * <td>Number</td>
  * <td><code>55</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>S</code></td>
  * <td>fractional second</td>
  * <td>Number</td>
  * <td><code>978</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>E</code></td>
  * <td>day of week</td>
  * <td>Text</td>
  * <td><code>Tuesday</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>c</code></td>
  * <td>standalone day of week</td>
  * <td>Text</td>
  * <td><code>Tuesday</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>a</code></td>
  * <td>am/pm marker</td>
  * <td>Text</td>
  * <td><code>PM</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>k</code></td>
  * <td>hour in day (1-24)</td>
  * <td>Number</td>
  * <td><code>24</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>K</code></td>
  * <td>hour in am/pm (0-11)</td>
  * <td>Number</td>
  * <td><code>0</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>z</code></td>
  * <td>time zone</td>
  * <td>Text</td>
  * <td><code>Pacific Standard Time(see comment)</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>Z</code></td>
  * <td>time zone (RFC 822)</td>
  * <td>Text</td>
  * <td><code>-0800(See comment)</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>v</code></td>
  * <td>time zone id</td>
  * <td>Text</td>
  * <td><code>America/Los_Angeles(See comment)</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>'</code></td>
  * <td>escape for text</td>
  * <td>Delimiter</td>
  * <td><code>'Date='</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>''</code></td>
  * <td>single quote</td>
@@ -173,58 +172,46 @@ import java.util.*;
  * <td><code>'o''clock'</code></td>
  * </tr>
  * </table>
- * 
- * <p>
- * The number of pattern letters influences the format, as follows:
- * </p>
- * 
+ *
+ * <p>The number of pattern letters influences the format, as follows:
+ *
  * <dl>
- * <dt>Text</dt>
- * <dd>if 4 or more, then use the full form; if less than 4, use short or
- * abbreviated form if it exists (e.g., <code>"EEEE"</code> produces
- * <code>"Monday"</code>, <code>"EEE"</code> produces <code>"Mon"</code>)</dd>
- * 
- * <dt>Number</dt>
- * <dd>the minimum number of digits. Shorter numbers are zero-padded to this
- * amount (e.g. if <code>"m"</code> produces <code>"6"</code>, <code>"mm"</code>
- * produces <code>"06"</code>). Year is handled specially; that is, if the count
- * of 'y' is 2, the Year will be truncated to 2 digits. (e.g., if
- * <code>"yyyy"</code> produces <code>"1997"</code>, <code>"yy"</code> produces
- * <code>"97"</code>.) Unlike other fields, fractional seconds are padded on the
- * right with zero.</dd>
- * 
- * <dt>Text or Number</dt>
- * <dd>3 or more, use text, otherwise use number. (e.g. <code>"M"</code>
- * produces <code>"1"</code>, <code>"MM"</code> produces <code>"01"</code>,
- * <code>"MMM"</code> produces <code>"Jan"</code>, and <code>"MMMM"</code>
- * produces <code>"January"</code>.  Some pattern letters also treat a count
- * of 5 specially, meaning a single-letter abbreviation: <code>L</code>,
- * <code>M</code>, <code>E</code>, and <code>c</code>.</dd>
+ *   <dt>Text
+ *   <dd>if 4 or more, then use the full form; if less than 4, use short or abbreviated form if it
+ *       exists (e.g., <code>"EEEE"</code> produces <code>"Monday"</code>, <code>"EEE"</code>
+ *       produces <code>"Mon"</code>)
+ *   <dt>Number
+ *   <dd>the minimum number of digits. Shorter numbers are zero-padded to this amount (e.g. if
+ *       <code>"m"</code> produces <code>"6"</code>, <code>"mm"</code> produces <code>"06"</code>).
+ *       Year is handled specially; that is, if the count of 'y' is 2, the Year will be truncated to
+ *       2 digits. (e.g., if <code>"yyyy"</code> produces <code>"1997"</code>, <code>"yy"</code>
+ *       produces <code>"97"</code>.) Unlike other fields, fractional seconds are padded on the
+ *       right with zero.
+ *   <dt>Text or Number
+ *   <dd>3 or more, use text, otherwise use number. (e.g. <code>"M"</code> produces <code>"1"</code>
+ *       , <code>"MM"</code> produces <code>"01"</code>, <code>"MMM"</code> produces <code>"Jan"
+ *       </code>, and <code>"MMMM"</code> produces <code>"January"</code>. Some pattern letters also
+ *       treat a count of 5 specially, meaning a single-letter abbreviation: <code>L</code>, <code>M
+ *       </code>, <code>E</code>, and <code>c</code>.
  * </dl>
- * 
- * <p>
- * Any characters in the pattern that are not in the ranges of ['<code>a</code>
- * '..'<code>z</code>'] and ['<code>A</code>'..'<code>Z</code>'] will be treated
- * as quoted text. For instance, characters like '<code>:</code>', '
- * <code>.</code>', '<code> </code>' (space), '<code>#</code>' and '
- * <code>@</code>' will appear in the resulting time text even they are not
- * embraced within single quotes.
- * </p>
- * 
- * <p>
- * [Time Zone Handling] Web browsers don't provide all the information we need
- * for proper time zone formating -- so GWT has a copy of the required data, for
- * your convenience. For simpler cases, one can also use a fallback
- * implementation that only keeps track of the current timezone offset. These
- * two approaches are called, respectively, Common TimeZones and Simple
- * TimeZones, although both are implemented with the same TimeZone class.
- * 
- * "TimeZone createTimeZone(String timezoneData)" returns a Common TimeZone
- * object, and "TimeZone createTimeZone(int timeZoneOffsetInMinutes)" returns a
- * Simple TimeZone object. The one provided by OS fall into to Simple TimeZone
- * category. For formatting purpose, following table shows the behavior of GWT
- * DateTimeFormat.
- * </p>
+ *
+ * <p>Any characters in the pattern that are not in the ranges of ['<code>a</code> '..'<code>z
+ * </code>'] and ['<code>A</code>'..'<code>Z</code>'] will be treated as quoted text. For instance,
+ * characters like '<code>:</code>', ' <code>.</code>', '<code> </code>' (space), '<code>#</code>'
+ * and ' <code>@</code>' will appear in the resulting time text even they are not embraced within
+ * single quotes.
+ *
+ * <p>[Time Zone Handling] Web browsers don't provide all the information we need for proper time
+ * zone formating -- so GWT has a copy of the required data, for your convenience. For simpler
+ * cases, one can also use a fallback implementation that only keeps track of the current timezone
+ * offset. These two approaches are called, respectively, Common TimeZones and Simple TimeZones,
+ * although both are implemented with the same TimeZone class.
+ *
+ * <p>"TimeZone createTimeZone(String timezoneData)" returns a Common TimeZone object, and "TimeZone
+ * createTimeZone(int timeZoneOffsetInMinutes)" returns a Simple TimeZone object. The one provided
+ * by OS fall into to Simple TimeZone category. For formatting purpose, following table shows the
+ * behavior of GWT DateTimeFormat.
+ *
  * <table>
  * <tr>
  * <th>Pattern</th>
@@ -262,146 +249,132 @@ import java.util.*;
  * <td>Etc/GMT+7</td>
  * </tr>
  * </table>
- * 
+ *
  * <h3>Parsing Dates and Times</h3>
- * <p>
- * The pattern does not need to specify every field.  If the year, month, or
- * day is missing from the pattern, the corresponding value will be taken from
- * the current date.  If the month is specified but the day is not, the day will
- * be constrained to the last day within the specified month.  If the hour,
- * minute, or second is missing, the value defaults to zero.
- * </p>
- * 
- * <p>
- * As with formatting (described above), the count of pattern letters determines
- * the parsing behavior.
- * </p>
- * 
+ *
+ * <p>The pattern does not need to specify every field. If the year, month, or day is missing from
+ * the pattern, the corresponding value will be taken from the current date. If the month is
+ * specified but the day is not, the day will be constrained to the last day within the specified
+ * month. If the hour, minute, or second is missing, the value defaults to zero.
+ *
+ * <p>As with formatting (described above), the count of pattern letters determines the parsing
+ * behavior.
+ *
  * <dl>
- * <dt>Text</dt>
- * <dd>4 or more pattern letters--use full form, less than 4--use short or
- * abbreviated form if one exists. In parsing, we will always try long format,
- * then short.</dd>
- * 
- * <dt>Number</dt>
- * <dd>the minimum number of digits.</dd>
- * 
- * <dt>Text or Number</dt>
- * <dd>3 or more characters means use text, otherwise use number</dd>
+ *   <dt>Text
+ *   <dd>4 or more pattern letters--use full form, less than 4--use short or abbreviated form if one
+ *       exists. In parsing, we will always try long format, then short.
+ *   <dt>Number
+ *   <dd>the minimum number of digits.
+ *   <dt>Text or Number
+ *   <dd>3 or more characters means use text, otherwise use number
  * </dl>
- * 
- * <p>
- * Although the current pattern specification doesn't not specify behavior for
- * all letters, it may in the future. It is strongly discouraged to use
- * unspecified letters as literal text without quoting them.
- * </p>
- * <p>
- * [Note on TimeZone] The time zone support for parsing is limited. Only
- * standard GMT and RFC format are supported. Time zone specification using time
- * zone id (like America/Los_Angeles), time zone names (like PST, Pacific
- * Standard Time) are not supported. Normally, it is too much a burden for a
- * client application to load all the time zone symbols. And in almost all those
- * cases, it is a better choice to do such parsing on server side through
- * certain RPC mechanism. This decision is based on particular use cases we have
- * studied; in principle, it could be changed in future versions.
- * </p>
- * 
+ *
+ * <p>Although the current pattern specification doesn't not specify behavior for all letters, it
+ * may in the future. It is strongly discouraged to use unspecified letters as literal text without
+ * quoting them.
+ *
+ * <p>[Note on TimeZone] The time zone support for parsing is limited. Only standard GMT and RFC
+ * format are supported. Time zone specification using time zone id (like America/Los_Angeles), time
+ * zone names (like PST, Pacific Standard Time) are not supported. Normally, it is too much a burden
+ * for a client application to load all the time zone symbols. And in almost all those cases, it is
+ * a better choice to do such parsing on server side through certain RPC mechanism. This decision is
+ * based on particular use cases we have studied; in principle, it could be changed in future
+ * versions.
+ *
  * <h3>Examples</h3>
+ *
  * <table>
  * <tr>
  * <th>Pattern</th>
  * <th>Formatted Text</th>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>"yyyy.MM.dd G 'at' HH:mm:ss vvvv"</code></td>
  * <td><code>1996.07.10 AD at 15:08:56 America/Los_Angeles</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>"EEE, MMM d, ''yy"</code></td>
  * <td><code>Wed, July 10, '96</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>"h:mm a"</code></td>
  * <td><code>12:08 PM</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>"hh 'o''clock' a, zzzz"</code></td>
  * <td><code> 12 o'clock PM, Pacific Daylight Time</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>"K:mm a, vvvv"</code></td>
  * <td><code> 0:00 PM, America/Los_Angeles</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>"yyyyy.MMMMM.dd GGG hh:mm aaa"</code></td>
  * <td><code>01996.July.10 AD 12:08 PM</code></td>
  * </tr>
  * </table>
- * 
+ *
  * <h3>Additional Parsing Considerations</h3>
- * <p>
- * When parsing a date string using the abbreviated year pattern (
- * <code>"yy"</code>), the parser must interpret the abbreviated year relative
- * to some century. It does this by adjusting dates to be within 80 years before
- * and 20 years after the time the parser instance is created. For example,
- * using a pattern of <code>"MM/dd/yy"</code> and a <code>DateTimeFormat</code>
- * object created on Jan 1, 1997, the string <code>"01/11/12"</code> would be
- * interpreted as Jan 11, 2012 while the string <code>"05/04/64"</code> would be
- * interpreted as May 4, 1964. During parsing, only strings consisting of
- * exactly two digits, as defined by {@link Character#isDigit(char)},
- * will be parsed into the default century. If the year pattern does not have
- * exactly two 'y' characters, the year is interpreted literally, regardless of
- * the number of digits. For example, using the pattern
- * <code>"MM/dd/yyyy"</code>, "01/11/12" parses to Jan 11, 12 A.D.
- * </p>
- * 
- * <p>
- * When numeric fields abut one another directly, with no intervening delimiter
- * characters, they constitute a run of abutting numeric fields. Such runs are
- * parsed specially. For example, the format "HHmmss" parses the input text
- * "123456" to 12:34:56, parses the input text "12345" to 1:23:45, and fails to
- * parse "1234". In other words, the leftmost field of the run is flexible,
- * while the others keep a fixed width. If the parse fails anywhere in the run,
- * then the leftmost field is shortened by one character, and the entire run is
- * parsed again. This is repeated until either the parse succeeds or the
- * leftmost field is one character in length. If the parse still fails at that
- * point, the parse of the run fails.
- * </p>
- * 
- * <p>
- * In the current implementation, timezone parsing only supports
- * <code>GMT:hhmm</code>, <code>GMT:+hhmm</code>, and <code>GMT:-hhmm</code>.
- * </p>
- * 
- * <h3>Example</h3> {@example com.google.gwt.examples.DateTimeFormatExample}
- * 
+ *
+ * <p>When parsing a date string using the abbreviated year pattern ( <code>"yy"</code>), the parser
+ * must interpret the abbreviated year relative to some century. It does this by adjusting dates to
+ * be within 80 years before and 20 years after the time the parser instance is created. For
+ * example, using a pattern of <code>"MM/dd/yy"</code> and a <code>DateTimeFormat</code> object
+ * created on Jan 1, 1997, the string <code>"01/11/12"</code> would be interpreted as Jan 11, 2012
+ * while the string <code>"05/04/64"</code> would be interpreted as May 4, 1964. During parsing,
+ * only strings consisting of exactly two digits, as defined by {@link Character#isDigit(char)},
+ * will be parsed into the default century. If the year pattern does not have exactly two 'y'
+ * characters, the year is interpreted literally, regardless of the number of digits. For example,
+ * using the pattern <code>"MM/dd/yyyy"</code>, "01/11/12" parses to Jan 11, 12 A.D.
+ *
+ * <p>When numeric fields abut one another directly, with no intervening delimiter characters, they
+ * constitute a run of abutting numeric fields. Such runs are parsed specially. For example, the
+ * format "HHmmss" parses the input text "123456" to 12:34:56, parses the input text "12345" to
+ * 1:23:45, and fails to parse "1234". In other words, the leftmost field of the run is flexible,
+ * while the others keep a fixed width. If the parse fails anywhere in the run, then the leftmost
+ * field is shortened by one character, and the entire run is parsed again. This is repeated until
+ * either the parse succeeds or the leftmost field is one character in length. If the parse still
+ * fails at that point, the parse of the run fails.
+ *
+ * <p>In the current implementation, timezone parsing only supports <code>GMT:hhmm</code>, <code>
+ * GMT:+hhmm</code>, and <code>GMT:-hhmm</code>.
+ *
+ * <h3>Example</h3>
+ *
+ * {@example com.google.gwt.examples.DateTimeFormatExample}
  */
 public class DateTimeFormat {
 
   /**
-   * Predefined date/time formats -- see {@link CustomDateTimeFormat} if you
-   * need some format that isn't supplied here.
+   * Predefined date/time formats -- see {@link CustomDateTimeFormat} if you need some format that
+   * isn't supplied here.
    */
   public enum PredefinedFormat {
     // TODO(jat): Javadoc to explain these formats
 
     /**
      * ISO 8601 date format, fixed across all locales.
+     *
      * <p>Example: {@code 2008-10-03T10:29:40.046-04:00}
+     *
      * <p>http://code.google.com/p/google-web-toolkit/issues/detail?id=3068
+     *
      * <p>http://www.iso.org/iso/support/faqs/faqs_widely_used_standards/widely_used_standards_other/date_and_time_format.htm
      */
     ISO_8601,
 
     /**
      * RFC 2822 date format, fixed across all locales.
+     *
      * <p>Example: {@code Thu, 20 May 2010 17:54:50 -0700}
+     *
      * <p>http://tools.ietf.org/html/rfc2822#section-3.3
      */
     RFC_2822,
@@ -445,9 +418,7 @@ public class DateTimeFormat {
     YEAR_QUARTER_ABBR,
   }
 
-  /**
-   * Class PatternPart holds a "compiled" pattern part.
-   */
+  /** Class PatternPart holds a "compiled" pattern part. */
   private static class PatternPart {
     public String text;
     public int count; // 0 has a special meaning, it stands for literal
@@ -488,10 +459,9 @@ public class DateTimeFormat {
 
   /**
    * Get a DateTimeFormat instance for a predefined format.
-   * 
-   * <p>See {@link CustomDateTimeFormat} if you need a localized format that is
-   * not supported here.
-   * 
+   *
+   * <p>See {@link CustomDateTimeFormat} if you need a localized format that is not supported here.
+   *
    * @param predef {@link PredefinedFormat} describing desired format
    * @return a DateTimeFormat instance for the specified format
    */
@@ -526,20 +496,16 @@ public class DateTimeFormat {
         pattern = dtfi.dateFormatShort();
         break;
       case DATE_TIME_FULL:
-        pattern = dtfi.dateTimeFull(dtfi.timeFormatFull(),
-            dtfi.dateFormatFull());
+        pattern = dtfi.dateTimeFull(dtfi.timeFormatFull(), dtfi.dateFormatFull());
         break;
       case DATE_TIME_LONG:
-        pattern = dtfi.dateTimeLong(dtfi.timeFormatLong(),
-            dtfi.dateFormatLong());
+        pattern = dtfi.dateTimeLong(dtfi.timeFormatLong(), dtfi.dateFormatLong());
         break;
       case DATE_TIME_MEDIUM:
-        pattern = dtfi.dateTimeMedium(dtfi.timeFormatMedium(),
-            dtfi.dateFormatMedium());
+        pattern = dtfi.dateTimeMedium(dtfi.timeFormatMedium(), dtfi.dateFormatMedium());
         break;
       case DATE_TIME_SHORT:
-        pattern = dtfi.dateTimeShort(dtfi.timeFormatShort(),
-            dtfi.dateFormatShort());
+        pattern = dtfi.dateTimeShort(dtfi.timeFormatShort(), dtfi.dateFormatShort());
         break;
       case DAY:
         pattern = dtfi.formatDay();
@@ -620,31 +586,25 @@ public class DateTimeFormat {
         pattern = dtfi.formatYearQuarterShort();
         break;
       default:
-        throw new IllegalArgumentException("Unexpected predefined format "
-            + predef);
+        throw new IllegalArgumentException("Unexpected predefined format " + predef);
     }
     return getFormat(pattern, dtfi);
   }
 
   /**
-   * Returns a DateTimeFormat object using the specified pattern. If you need to
-   * format or parse repeatedly using the same pattern, it is highly recommended
-   * that you cache the returned <code>DateTimeFormat</code> object and reuse it
-   * rather than calling this method repeatedly.
-   * 
-   * <p>Note that the pattern supplied is used as-is -- for example, if you
-   * supply "MM/dd/yyyy" as the pattern, that is the order you will get the
-   * fields, even in locales where the order is different.  It is recommended to
-   * use {@link #getFormat(PredefinedFormat)} instead -- if you use this method,
-   * you are taking responsibility for localizing the patterns yourself.
-   * 
+   * Returns a DateTimeFormat object using the specified pattern. If you need to format or parse
+   * repeatedly using the same pattern, it is highly recommended that you cache the returned <code>
+   * DateTimeFormat</code> object and reuse it rather than calling this method repeatedly.
+   *
+   * <p>Note that the pattern supplied is used as-is -- for example, if you supply "MM/dd/yyyy" as
+   * the pattern, that is the order you will get the fields, even in locales where the order is
+   * different. It is recommended to use {@link #getFormat(PredefinedFormat)} instead -- if you use
+   * this method, you are taking responsibility for localizing the patterns yourself.
+   *
    * @param pattern string to specify how the date should be formatted
-   * 
-   * @return a <code>DateTimeFormat</code> object that can be used for format or
-   *         parse date/time values matching the specified pattern
-   * 
-   * @throws IllegalArgumentException if the specified pattern could not be
-   *           parsed
+   * @return a <code>DateTimeFormat</code> object that can be used for format or parse date/time
+   *     values matching the specified pattern
+   * @throws IllegalArgumentException if the specified pattern could not be parsed
    */
   public static DateTimeFormat getFormat(String pattern) {
     return getFormat(pattern, getDefaultDateTimeFormatInfo());
@@ -652,13 +612,12 @@ public class DateTimeFormat {
 
   /**
    * Internal factory method that provides caching.
-   * 
+   *
    * @param pattern
    * @param dtfi
    * @return DateTimeFormat instance
    */
-  protected static DateTimeFormat getFormat(String pattern,
-                                            DateTimeFormatInfo dtfi) {
+  protected static DateTimeFormat getFormat(String pattern, DateTimeFormatInfo dtfi) {
     DateTimeFormatInfo defaultDtfi = getDefaultDateTimeFormatInfo();
     DateTimeFormat dtf = null;
     if (dtfi == defaultDtfi) {
@@ -678,10 +637,12 @@ public class DateTimeFormat {
   }
 
   /**
-   * Returns true if the predefined format is one that specifies always using
-   * English names/separators.
-   * <p>This should be a method on PredefinedFormat, but that would defeat the
-   * enum optimizations GWT is currently capable of.
+   * Returns true if the predefined format is one that specifies always using English
+   * names/separators.
+   *
+   * <p>This should be a method on PredefinedFormat, but that would defeat the enum optimizations
+   * GWT is currently capable of.
+   *
    * @param predef
    * @return true if the specified format requires English names/separators
    */
@@ -703,9 +664,9 @@ public class DateTimeFormat {
   private final String pattern;
 
   /**
-   * Constructs a format object using the specified pattern and the date time
-   * constants for the default locale.
-   * 
+   * Constructs a format object using the specified pattern and the date time constants for the
+   * default locale.
+   *
    * @param pattern string pattern specification
    */
   protected DateTimeFormat(String pattern) {
@@ -713,9 +674,8 @@ public class DateTimeFormat {
   }
 
   /**
-   * Constructs a format object using the specified pattern and user-supplied
-   * date time constants.
-   * 
+   * Constructs a format object using the specified pattern and user-supplied date time constants.
+   *
    * @param pattern string pattern specification
    * @param dtfi DateTimeFormatInfo instance to use
    */
@@ -733,9 +693,8 @@ public class DateTimeFormat {
 
   /**
    * Format a date object.
-   * 
+   *
    * @param date the date object being formatted
-   * 
    * @return string representation for this date in desired format
    */
   public String format(Date date) {
@@ -744,13 +703,11 @@ public class DateTimeFormat {
 
   /**
    * Format a date object using specified time zone.
-   * 
+   *
    * @param date the date object being formatted
-   * @param timeZone a TimeZone object that holds time zone information, or
-   *     {@code null} to use the default
-   * 
-   * @return string representation for this date in the format defined by this
-   *         object
+   * @param timeZone a TimeZone object that holds time zone information, or {@code null} to use the
+   *     default
+   * @return string representation for this date in the format defined by this object
    */
   @SuppressWarnings("deprecation")
   public String format(Date date, TimeZone timeZone) {
@@ -796,13 +753,12 @@ public class DateTimeFormat {
 
     StringBuilder toAppendTo = new StringBuilder(64);
     int j, n = pattern.length();
-    for (int i = 0; i < n;) {
+    for (int i = 0; i < n; ) {
       char ch = pattern.charAt(i);
       if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')) {
         // ch is a date-time pattern character to be interpreted by subFormat().
         // Count the number of times it is repeated.
-        for (j = i + 1; j < n && pattern.charAt(j) == ch; ++j) {
-        }
+        for (j = i + 1; j < n && pattern.charAt(j) == ch; ++j) {}
         subFormat(toAppendTo, ch, j - i, date, keepDate, keepTime, timeZone);
         i = j;
       } else if (ch == '\'') {
@@ -854,7 +810,7 @@ public class DateTimeFormat {
 
   /**
    * Retrieve the pattern used in this DateTimeFormat object.
-   * 
+   *
    * @return pattern string
    */
   public String getPattern() {
@@ -862,33 +818,30 @@ public class DateTimeFormat {
   }
 
   /**
-   * Parses text to produce a {@link Date} value. An
-   * {@link IllegalArgumentException} is thrown if either the text is empty or
-   * if the parse does not consume all characters of the text.
-   * 
-   * Dates are parsed leniently, so invalid dates will be wrapped around as
-   * needed. For example, February 30 will wrap to March 2.
-   * 
+   * Parses text to produce a {@link Date} value. An {@link IllegalArgumentException} is thrown if
+   * either the text is empty or if the parse does not consume all characters of the text.
+   *
+   * <p>Dates are parsed leniently, so invalid dates will be wrapped around as needed. For example,
+   * February 30 will wrap to March 2.
+   *
    * @param text the string being parsed
    * @return a parsed date/time value
-   * @throws IllegalArgumentException if the entire text could not be converted
-   *           into a number
+   * @throws IllegalArgumentException if the entire text could not be converted into a number
    */
   public Date parse(String text) throws IllegalArgumentException {
     return parse(text, false);
   }
 
   /**
-   * This method modifies a {@link Date} object to reflect the date that is
-   * parsed from an input string.
-   * 
-   * Dates are parsed leniently, so invalid dates will be wrapped around as
-   * needed. For example, February 30 will wrap to March 2.
-   * 
+   * This method modifies a {@link Date} object to reflect the date that is parsed from an input
+   * string.
+   *
+   * <p>Dates are parsed leniently, so invalid dates will be wrapped around as needed. For example,
+   * February 30 will wrap to March 2.
+   *
    * @param text the string that need to be parsed
    * @param start the character position in "text" where parsing should start
    * @param date the date object that will hold parsed value
-   * 
    * @return 0 if parsing failed, otherwise the number of characters advanced
    */
   public int parse(String text, int start, Date date) {
@@ -896,33 +849,30 @@ public class DateTimeFormat {
   }
 
   /**
-   * Parses text to produce a {@link Date} value. An
-   * {@link IllegalArgumentException} is thrown if either the text is empty or
-   * if the parse does not consume all characters of the text.
-   * 
-   * Dates are parsed strictly, so invalid dates will result in an
-   * {@link IllegalArgumentException}.
-   * 
+   * Parses text to produce a {@link Date} value. An {@link IllegalArgumentException} is thrown if
+   * either the text is empty or if the parse does not consume all characters of the text.
+   *
+   * <p>Dates are parsed strictly, so invalid dates will result in an {@link
+   * IllegalArgumentException}.
+   *
    * @param text the string being parsed
    * @return a parsed date/time value
-   * @throws IllegalArgumentException if the entire text could not be converted
-   *           into a number
+   * @throws IllegalArgumentException if the entire text could not be converted into a number
    */
   public Date parseStrict(String text) throws IllegalArgumentException {
     return parse(text, true);
   }
 
   /**
-   * This method modifies a {@link Date} object to reflect the date that is
-   * parsed from an input string.
-   * 
-   * Dates are parsed strictly, so invalid dates will return 0. For example,
-   * February 30 will return 0 because February only has 28 days.
-   * 
+   * This method modifies a {@link Date} object to reflect the date that is parsed from an input
+   * string.
+   *
+   * <p>Dates are parsed strictly, so invalid dates will return 0. For example, February 30 will
+   * return 0 because February only has 28 days.
+   *
    * @param text the string that need to be parsed
    * @param start the character position in "text" where parsing should start
    * @param date the date object that will hold parsed value
-   * 
    * @return 0 if parsing failed, otherwise the number of characters advanced
    */
   public int parseStrict(String text, int start, Date date) {
@@ -939,9 +889,9 @@ public class DateTimeFormat {
   }
 
   /**
-   * Method append current content in buf as pattern part if there is any, and
-   * clear buf for next part.
-   * 
+   * Method append current content in buf as pattern part if there is any, and clear buf for next
+   * part.
+   *
    * @param buf pattern part text specification
    * @param count pattern part repeat count
    */
@@ -954,10 +904,9 @@ public class DateTimeFormat {
 
   /**
    * Formats (0..11) Hours field according to pattern specified.
-   * 
+   *
    * @param buf where formatted string will be appended to
-   * @param count number of time pattern char repeats; this controls how a field
-   *          should be formatted
+   * @param count number of time pattern char repeats; this controls how a field should be formatted
    * @param date hold the date object to be formatted
    */
   @SuppressWarnings("deprecation")
@@ -968,10 +917,9 @@ public class DateTimeFormat {
 
   /**
    * Formats (0..23) Hours field according to pattern specified.
-   * 
+   *
    * @param buf where formatted string will be appended to
-   * @param count number of time pattern char repeats; this controls how a field
-   *          should be formatted
+   * @param count number of time pattern char repeats; this controls how a field should be formatted
    * @param date hold the date object to be formatted
    */
   @SuppressWarnings("deprecation")
@@ -982,10 +930,9 @@ public class DateTimeFormat {
 
   /**
    * Formats (1..12) Hours field according to pattern specified.
-   * 
+   *
    * @param buf where formatted string will be appended to
-   * @param count number of time pattern char repeats; this controls how a field
-   *          should be formatted
+   * @param count number of time pattern char repeats; this controls how a field should be formatted
    * @param date hold the date object to be formatted
    */
   @SuppressWarnings("deprecation")
@@ -1000,10 +947,9 @@ public class DateTimeFormat {
 
   /**
    * Formats (1..24) Hours field according to pattern specified.
-   * 
+   *
    * @param buf where formatted string will be appended to
-   * @param count number of time pattern char repeats; this controls how a field
-   *          should be formatted
+   * @param count number of time pattern char repeats; this controls how a field should be formatted
    * @param date hold the date object to be formatted
    */
   @SuppressWarnings("deprecation")
@@ -1018,7 +964,7 @@ public class DateTimeFormat {
 
   /**
    * Formats AM/PM field according to pattern specified.
-   * 
+   *
    * @param buf where formatted string will be appended to
    * @param date hold the date object to be formatted
    */
@@ -1033,10 +979,9 @@ public class DateTimeFormat {
 
   /**
    * Formats Date field according to pattern specified.
-   * 
+   *
    * @param buf where formatted string will be appended to
-   * @param count number of time pattern char repeats; this controls how a field
-   *          should be formatted
+   * @param count number of time pattern char repeats; this controls how a field should be formatted
    * @param date hold the date object to be formatted
    */
   private void formatDate(StringBuilder buf, int count, Date date) {
@@ -1047,10 +992,9 @@ public class DateTimeFormat {
 
   /**
    * Formats Day of week field according to pattern specified.
-   * 
+   *
    * @param buf where formatted string will be appended to
-   * @param count number of time pattern char repeats; this controls how a field
-   *          should be formatted
+   * @param count number of time pattern char repeats; this controls how a field should be formatted
    * @param date hold the date object to be formatted
    */
   private void formatDayOfWeek(StringBuilder buf, int count, Date date) {
@@ -1067,10 +1011,9 @@ public class DateTimeFormat {
 
   /**
    * Formats Era field according to pattern specified.
-   * 
+   *
    * @param buf where formatted string will be appended to
-   * @param count number of time pattern char repeats; this controls how a field
-   *          should be formatted
+   * @param count number of time pattern char repeats; this controls how a field should be formatted
    * @param date hold the date object to be formatted
    */
   private void formatEra(StringBuilder buf, int count, Date date) {
@@ -1085,10 +1028,9 @@ public class DateTimeFormat {
 
   /**
    * Formats Fractional seconds field according to pattern specified.
-   * 
+   *
    * @param buf where formatted string will be appended to
-   * @param count number of time pattern char repeats; this controls how a field
-   *          should be formatted
+   * @param count number of time pattern char repeats; this controls how a field should be formatted
    * @param date hold the date object to be formatted
    */
   private void formatFractionalSeconds(StringBuilder buf, int count, Date date) {
@@ -1096,7 +1038,7 @@ public class DateTimeFormat {
      * Fractional seconds should be left-justified, ie. zero must be padded from
      * left. For example, if the value in milliseconds is 5, and the count is 3,
      * the output will be "005".
-     * 
+     *
      * Values with less than three digits are rounded to the desired number of
      * places, but the rounded values are truncated at 9 or 99 in order to avoid
      * changing the values of seconds.
@@ -1128,10 +1070,9 @@ public class DateTimeFormat {
 
   /**
    * Formats Minutes field according to pattern specified.
-   * 
+   *
    * @param buf where formatted string will be appended to
-   * @param count number of time pattern char repeats; this controls how a field
-   *          should be formatted
+   * @param count number of time pattern char repeats; this controls how a field should be formatted
    * @param date hold the date object to be formatted
    */
   private void formatMinutes(StringBuilder buf, int count, Date date) {
@@ -1142,10 +1083,9 @@ public class DateTimeFormat {
 
   /**
    * Formats Month field according to pattern specified.
-   * 
+   *
    * @param buf where formatted string will be appended to
-   * @param count number of time pattern char repeats; this controls how a field
-   *          should be formatted
+   * @param count number of time pattern char repeats; this controls how a field should be formatted
    * @param date hold the date object to be formatted
    */
   private void formatMonth(StringBuilder buf, int count, Date date) {
@@ -1168,10 +1108,9 @@ public class DateTimeFormat {
 
   /**
    * Formats Quarter field according to pattern specified.
-   * 
+   *
    * @param buf where formatted string will be appended to
-   * @param count number of time pattern char repeats; this controls how a field
-   *          should be formatted
+   * @param count number of time pattern char repeats; this controls how a field should be formatted
    * @param date hold the date object to be formatted
    */
   private void formatQuarter(StringBuilder buf, int count, Date date) {
@@ -1186,10 +1125,9 @@ public class DateTimeFormat {
 
   /**
    * Formats Seconds field according to pattern specified.
-   * 
+   *
    * @param buf where formatted string will be appended to
-   * @param count number of time pattern char repeats; this controls how a field
-   *          should be formatted
+   * @param count number of time pattern char repeats; this controls how a field should be formatted
    * @param date hold the date object to be formatted
    */
   private void formatSeconds(StringBuilder buf, int count, Date date) {
@@ -1200,10 +1138,9 @@ public class DateTimeFormat {
 
   /**
    * Formats Standalone weekday field according to pattern specified.
-   * 
+   *
    * @param buf where formatted string will be appended to
-   * @param count number of time pattern char repeats; this controls how a field
-   *          should be formatted
+   * @param count number of time pattern char repeats; this controls how a field should be formatted
    * @param date hold the date object to be formatted
    */
   private void formatStandaloneDay(StringBuilder buf, int count, Date date) {
@@ -1222,10 +1159,9 @@ public class DateTimeFormat {
 
   /**
    * Formats Standalone Month field according to pattern specified.
-   * 
+   *
    * @param buf where formatted string will be appended to
-   * @param count number of time pattern char repeats; this controls how a field
-   *          should be formatted
+   * @param count number of time pattern char repeats; this controls how a field should be formatted
    * @param date hold the date object to be formatted
    */
   private void formatStandaloneMonth(StringBuilder buf, int count, Date date) {
@@ -1244,14 +1180,12 @@ public class DateTimeFormat {
 
   /**
    * Formats Timezone field.
-   * 
+   *
    * @param buf where formatted string will be appended to
-   * @param count number of time pattern char repeats; this controls how a field
-   *          should be formatted
+   * @param count number of time pattern char repeats; this controls how a field should be formatted
    * @param date hold the date object to be formatted
    */
-  private void formatTimeZone(StringBuilder buf, int count, Date date,
-      TimeZone timeZone) {
+  private void formatTimeZone(StringBuilder buf, int count, Date date, TimeZone timeZone) {
     if (count < 4) {
       buf.append(timeZone.getShortName(date));
     } else {
@@ -1261,14 +1195,12 @@ public class DateTimeFormat {
 
   /**
    * Formats Timezone field following RFC.
-   * 
+   *
    * @param buf where formatted string will be appended to
-   * @param count number of time pattern char repeats; this controls how a field
-   *          should be formatted
+   * @param count number of time pattern char repeats; this controls how a field should be formatted
    * @param date hold the date object to be formatted
    */
-  private void formatTimeZoneRFC(StringBuilder buf, int count, Date date,
-      TimeZone timeZone) {
+  private void formatTimeZoneRFC(StringBuilder buf, int count, Date date, TimeZone timeZone) {
     if (count < 3) {
       buf.append(timeZone.getRFCTimeZoneString(date));
     } else if (count == 3) {
@@ -1279,15 +1211,15 @@ public class DateTimeFormat {
   }
 
   /**
-   * Formats Year field according to pattern specified. Javascript Date object
-   * seems incapable handling 1BC and year before. It can show you year 0 which
-   * does not exists. following we just keep consistent with javascript's
-   * toString method. But keep in mind those things should be unsupported.
-   * 
+   * Formats Year field according to pattern specified. Javascript Date object seems incapable
+   * handling 1BC and year before. It can show you year 0 which does not exists. following we just
+   * keep consistent with javascript's toString method. But keep in mind those things should be
+   * unsupported.
+   *
    * @param buf where formatted string will be appended to
-   * @param count number of time pattern char repeats; this controls how a field
-   *     should be formatted; 2 is treated specially with the last two digits of
-   *     the year, while more than 2 digits are zero-padded
+   * @param count number of time pattern char repeats; this controls how a field should be
+   *     formatted; 2 is treated specially with the last two digits of the year, while more than 2
+   *     digits are zero-padded
    * @param date hold the date object to be formatted
    */
   private void formatYear(StringBuilder buf, int count, Date date) {
@@ -1310,9 +1242,8 @@ public class DateTimeFormat {
   }
 
   /**
-   * Method getNextCharCountInPattern calculate character repeat count in
-   * pattern.
-   * 
+   * Method getNextCharCountInPattern calculate character repeat count in pattern.
+   *
    * @param pattern describe the format of date string that need to be parsed
    * @param start the position of pattern character
    * @return repeat count
@@ -1327,14 +1258,12 @@ public class DateTimeFormat {
   }
 
   /**
-   * Method identifies the start of a run of abutting numeric fields. Take the
-   * pattern "HHmmss" as an example. We will try to parse 2/2/2 characters of
-   * the input text, then if that fails, 1/2/2. We only adjust the width of the
-   * leftmost field; the others remain fixed. This allows "123456" => 12:34:56,
-   * but "12345" => 1:23:45. Likewise, for the pattern "yyyyMMdd" we try 4/2/2,
-   * 3/2/2, 2/2/2, and finally 1/2/2. The first field of connected numeric
-   * fields will be marked as abutStart, its width can be reduced to accommodate
-   * others.
+   * Method identifies the start of a run of abutting numeric fields. Take the pattern "HHmmss" as
+   * an example. We will try to parse 2/2/2 characters of the input text, then if that fails, 1/2/2.
+   * We only adjust the width of the leftmost field; the others remain fixed. This allows "123456"
+   * => 12:34:56, but "12345" => 1:23:45. Likewise, for the pattern "yyyyMMdd" we try 4/2/2, 3/2/2,
+   * 2/2/2, and finally 1/2/2. The first field of connected numeric fields will be marked as
+   * abutStart, its width can be reduced to accommodate others.
    */
   private void identifyAbutStart() {
     // 'abut' parts are continuous numeric parts. abutStart is the switch
@@ -1357,7 +1286,7 @@ public class DateTimeFormat {
 
   /**
    * Method checks if the pattern part is a numeric field.
-   * 
+   *
    * @param part pattern part to be examined
    * @return <code>true</code> if the pattern part is numberic field
    */
@@ -1371,17 +1300,16 @@ public class DateTimeFormat {
   }
 
   /**
-   * Method attempts to match the text at a given position against an array of
-   * strings. Since multiple strings in the array may match (for example, if the
-   * array contains "a", "ab", and "abc", all will match the input string
-   * "abcd") the longest match is returned.
-   * 
+   * Method attempts to match the text at a given position against an array of strings. Since
+   * multiple strings in the array may match (for example, if the array contains "a", "ab", and
+   * "abc", all will match the input string "abcd") the longest match is returned.
+   *
    * @param text the time text being parsed
    * @param start where to start parsing
    * @param data the string array to parsed
    * @param pos to receive where the match stopped
-   * @return the new start position if matching succeeded; a negative number
-   *         indicating matching failure
+   * @return the new start position if matching succeeded; a negative number indicating matching
+   *     failure
    */
   private int matchString(String text, int start, String[] data, int[] pos) {
     int count = data.length;
@@ -1409,25 +1337,22 @@ public class DateTimeFormat {
   }
 
   /**
-   * Parses text to produce a {@link Date} value. An
-   * {@link IllegalArgumentException} is thrown if either the text is empty or
-   * if the parse does not consume all characters of the text.
-   * 
-   * If using lenient parsing, certain invalid dates and times will be parsed.
-   * For example, February 32nd would be parsed as March 4th in lenient mode,
-   * but would throw an exception in non-lenient mode.
-   * 
+   * Parses text to produce a {@link Date} value. An {@link IllegalArgumentException} is thrown if
+   * either the text is empty or if the parse does not consume all characters of the text.
+   *
+   * <p>If using lenient parsing, certain invalid dates and times will be parsed. For example,
+   * February 32nd would be parsed as March 4th in lenient mode, but would throw an exception in
+   * non-lenient mode.
+   *
    * @param text the string being parsed
    * @param strict true to be strict when parsing, false to be lenient
    * @return a parsed date/time value
-   * @throws IllegalArgumentException if the entire text could not be converted
-   *           into a number
+   * @throws IllegalArgumentException if the entire text could not be converted into a number
    */
   private Date parse(String text, boolean strict) {
     Date curDate = new Date();
     @SuppressWarnings("deprecation")
-    Date date = new Date(curDate.getYear(), curDate.getMonth(),
-        curDate.getDate());
+    Date date = new Date(curDate.getYear(), curDate.getMonth(), curDate.getDate());
     int charsConsumed = parse(text, 0, date, strict);
     if (charsConsumed == 0 || charsConsumed < text.length()) {
       throw new IllegalArgumentException(text);
@@ -1436,18 +1361,16 @@ public class DateTimeFormat {
   }
 
   /**
-   * This method parses the input string and fills its value into a {@link Date}
-   * .
-   * 
-   * If using lenient parsing, certain invalid dates and times will be parsed.
-   * For example, February 32nd would be parsed as March 4th in lenient mode,
-   * but would return 0 in non-lenient mode.
-   * 
+   * This method parses the input string and fills its value into a {@link Date} .
+   *
+   * <p>If using lenient parsing, certain invalid dates and times will be parsed. For example,
+   * February 32nd would be parsed as March 4th in lenient mode, but would return 0 in non-lenient
+   * mode.
+   *
    * @param text the string that need to be parsed
    * @param start the character position in "text" where parsing should start
    * @param date the date object that will hold parsed value
    * @param strict true to be strict when parsing, false to be lenient
-   * 
    * @return 0 if parsing failed, otherwise the number of characters advanced
    */
   private int parse(String text, int start, Date date, boolean strict) {
@@ -1543,10 +1466,9 @@ public class DateTimeFormat {
 
   /**
    * Method parses a integer string and return integer value.
-   * 
+   *
    * @param text string being parsed
    * @param pos parse position
-   * 
    * @return integer value
    */
   private int parseInt(String text, int[] pos) {
@@ -1573,9 +1495,8 @@ public class DateTimeFormat {
   }
 
   /**
-   * Method parses the input pattern string a generate a vector of pattern
-   * parts.
-   * 
+   * Method parses the input pattern string a generate a vector of pattern parts.
+   *
    * @param pattern describe the format of date string that need to be parsed
    */
   private void parsePattern(String pattern) {
@@ -1643,13 +1564,11 @@ public class DateTimeFormat {
 
   /**
    * Method parses time zone offset.
-   * 
+   *
    * @param text the time text to be parsed
    * @param pos Parse position
    * @param cal DateRecord object that holds parsed value
-   * 
-   * @return <code>true</code> if parsing successful, otherwise
-   *         <code>false</code>
+   * @return <code>true</code> if parsing successful, otherwise <code>false</code>
    */
   private boolean parseTimeZoneOffset(String text, int[] pos, DateRecord cal) {
     if (pos[0] >= text.length()) {
@@ -1707,32 +1626,34 @@ public class DateTimeFormat {
 
   /**
    * Method skips space in the string as pointed by pos.
-   * 
+   *
    * @param text input string
    * @param pos where skip start, and return back where skip stop
    */
   private void skipSpace(String text, int[] pos) {
-    while (pos[0] < text.length()
-        && WHITE_SPACE.indexOf(text.charAt(pos[0])) >= 0) {
+    while (pos[0] < text.length() && WHITE_SPACE.indexOf(text.charAt(pos[0])) >= 0) {
       ++(pos[0]);
     }
   }
 
   /**
    * Formats a single field according to pattern specified.
-   * 
+   *
    * @param ch pattern character for this field
-   * @param count number of time pattern char repeats; this controls how a field
-   *          should be formatted
+   * @param count number of time pattern char repeats; this controls how a field should be formatted
    * @param date the date object to be formatted
    * @param adjustedDate holds the time zone adjusted date fields
    * @param adjustedTime holds the time zone adjusted time fields
-   * 
    * @return <code>true</code> if pattern valid, otherwise <code>false</code>
-   * 
    */
-  private boolean subFormat(StringBuilder buf, char ch, int count, Date date,
-      Date adjustedDate, Date adjustedTime, TimeZone timezone) {
+  private boolean subFormat(
+      StringBuilder buf,
+      char ch,
+      int count,
+      Date date,
+      Date adjustedDate,
+      Date adjustedTime,
+      TimeZone timezone) {
     switch (ch) {
       case 'G':
         formatEra(buf, count, adjustedDate);
@@ -1798,20 +1719,19 @@ public class DateTimeFormat {
   }
 
   /**
-   * Converts one field of the input string into a numeric field value. Returns
-   * <code>false</code> if failed.
-   * 
+   * Converts one field of the input string into a numeric field value. Returns <code>false</code>
+   * if failed.
+   *
    * @param text the time text to be parsed
    * @param pos Parse position
    * @param part the pattern part for this field
    * @param digitCount when greater than 0, numeric parsing must obey the count
    * @param cal DateRecord object that will hold parsed value
-   * 
    * @return <code>true</code> if parsing successful
    */
   @SuppressWarnings("fallthrough")
-  private boolean subParse(String text, int[] pos, PatternPart part,
-      int digitCount, DateRecord cal) {
+  private boolean subParse(
+      String text, int[] pos, PatternPart part, int digitCount, DateRecord cal) {
 
     skipSpace(text, pos);
 
@@ -1912,17 +1832,14 @@ public class DateTimeFormat {
 
   /**
    * Method subParseDayOfWeek parses day of the week field.
-   * 
+   *
    * @param text the time text to be parsed
    * @param pos Parse position
    * @param start from where parse start
    * @param cal DateRecord object that holds parsed value
-   * 
-   * @return <code>true</code> if parsing successful, otherwise
-   *         <code>false</code>
+   * @return <code>true</code> if parsing successful, otherwise <code>false</code>
    */
-  private boolean subParseDayOfWeek(String text, int[] pos, int start,
-      DateRecord cal) {
+  private boolean subParseDayOfWeek(String text, int[] pos, int start, DateRecord cal) {
     int value;
     // 'E' - DAY_OF_WEEK
     // Want to be able to parse both short and long forms.
@@ -1940,16 +1857,14 @@ public class DateTimeFormat {
 
   /**
    * Method subParseFractionalSeconds parses fractional seconds field.
-   * 
+   *
    * @param value parsed numberic value
    * @param start
    * @param end parse position
    * @param cal DateRecord object that holds parsed value
-   * @return <code>true</code> if parsing successful, otherwise
-   *         <code>false</code>
+   * @return <code>true</code> if parsing successful, otherwise <code>false</code>
    */
-  private boolean subParseFractionalSeconds(int value, int start, int end,
-      DateRecord cal) {
+  private boolean subParseFractionalSeconds(int value, int start, int end, DateRecord cal) {
     // Fractional seconds left-justify.
     int i = end - start;
     if (i < 3) {
@@ -1971,18 +1886,15 @@ public class DateTimeFormat {
 
   /**
    * Parses Month field.
-   * 
+   *
    * @param text the time text to be parsed
    * @param pos Parse position
    * @param cal DateRecord object that will hold parsed value
-   * @param value numeric value if this field is expressed using numberic
-   *          pattern
+   * @param value numeric value if this field is expressed using numberic pattern
    * @param start from where parse start
-   * 
    * @return <code>true</code> if parsing successful
    */
-  private boolean subParseMonth(String text, int[] pos, DateRecord cal,
-      int value, int start) {
+  private boolean subParseMonth(String text, int[] pos, DateRecord cal, int value, int start) {
     // When month is symbols, i.e., MMM or MMMM, value will be -1.
     if (value < 0) {
       // Want to be able to parse both short and long forms.
@@ -2005,26 +1917,21 @@ public class DateTimeFormat {
 
   /**
    * Parses standalone day of the week field.
-   * 
+   *
    * @param text the time text to be parsed
    * @param pos Parse position
    * @param start from where parse start
    * @param cal DateRecord object that holds parsed value
-   * 
-   * @return <code>true</code> if parsing successful, otherwise
-   *         <code>false</code>
+   * @return <code>true</code> if parsing successful, otherwise <code>false</code>
    */
-  private boolean subParseStandaloneDay(String text, int[] pos, int start,
-      DateRecord cal) {
+  private boolean subParseStandaloneDay(String text, int[] pos, int start, DateRecord cal) {
     int value;
     // 'c' - DAY_OF_WEEK
     // Want to be able to parse both short and long forms.
     // Try count == 4 (cccc) first:
-    value = matchString(text, start, dateTimeFormatInfo.weekdaysFullStandalone(),
-        pos);
+    value = matchString(text, start, dateTimeFormatInfo.weekdaysFullStandalone(), pos);
     if (value < 0) {
-      value = matchString(text, start,
-          dateTimeFormatInfo.weekdaysShortStandalone(), pos);
+      value = matchString(text, start, dateTimeFormatInfo.weekdaysShortStandalone(), pos);
     }
     if (value < 0) {
       return false;
@@ -2035,27 +1942,23 @@ public class DateTimeFormat {
 
   /**
    * Parses a standalone month field.
-   * 
+   *
    * @param text the time text to be parsed
    * @param pos Parse position
    * @param cal DateRecord object that will hold parsed value
-   * @param value numeric value if this field is expressed using numberic
-   *          pattern
+   * @param value numeric value if this field is expressed using numberic pattern
    * @param start from where parse start
-   * 
    * @return <code>true</code> if parsing successful
    */
-  private boolean subParseStandaloneMonth(String text, int[] pos,
-      DateRecord cal, int value, int start) {
+  private boolean subParseStandaloneMonth(
+      String text, int[] pos, DateRecord cal, int value, int start) {
     // When month is symbols, i.e., LLL or LLLL, value will be -1.
     if (value < 0) {
       // Want to be able to parse both short and long forms.
       // Try count == 4 first:
-      value = matchString(text, start,
-          dateTimeFormatInfo.monthsFullStandalone(), pos);
+      value = matchString(text, start, dateTimeFormatInfo.monthsFullStandalone(), pos);
       if (value < 0) { // count == 4 failed, now try count == 3.
-        value = matchString(text, start,
-            dateTimeFormatInfo.monthsShortStandalone(), pos);
+        value = matchString(text, start, dateTimeFormatInfo.monthsShortStandalone(), pos);
       }
       if (value < 0) {
         return false;
@@ -2071,17 +1974,14 @@ public class DateTimeFormat {
 
   /**
    * Method parses GMT type timezone.
-   * 
+   *
    * @param text the time text to be parsed
    * @param start from where parse start
    * @param pos Parse position
    * @param cal DateRecord object that holds parsed value
-   * 
-   * @return <code>true</code> if parsing successful, otherwise
-   *         <code>false</code>
+   * @return <code>true</code> if parsing successful, otherwise <code>false</code>
    */
-  private boolean subParseTimeZoneInGMT(String text, int start, int[] pos,
-      DateRecord cal) {
+  private boolean subParseTimeZoneInGMT(String text, int start, int[] pos, DateRecord cal) {
     // First try to parse generic forms such as GMT-07:00. Do this first
     // in case localized DateFormatZoneData contains the string "GMT"
     // for a zone; in that case, we don't want to match the first three
@@ -2117,24 +2017,22 @@ public class DateTimeFormat {
   }
 
   /**
-   * Method subParseYear parse year field. Year field is special because 1, two
-   * digit year need to be resolved. 2, we allow year to take a sign. 3, year
-   * field participate in abut processing. In my testing, negative year does not
-   * seem working due to JDK (or GWT implementation) limitation. It is not a
-   * big deal so we don't worry about it. But keep the logic here so that we
-   * might want to replace DateRecord with our a calendar class.
-   * 
+   * Method subParseYear parse year field. Year field is special because 1, two digit year need to
+   * be resolved. 2, we allow year to take a sign. 3, year field participate in abut processing. In
+   * my testing, negative year does not seem working due to JDK (or GWT implementation) limitation.
+   * It is not a big deal so we don't worry about it. But keep the logic here so that we might want
+   * to replace DateRecord with our a calendar class.
+   *
    * @param text the time text to be parsed
    * @param pos parse position
    * @param start where this field starts
    * @param value integer value of year
    * @param part the pattern part for this field
    * @param cal DateRecord object that will hold parsed value
-   * 
    * @return <code>true</code> if successful
    */
-  private boolean subParseYear(String text, int[] pos, int start, int value,
-      PatternPart part, DateRecord cal) {
+  private boolean subParseYear(
+      String text, int[] pos, int start, int value, PatternPart part, DateRecord cal) {
     char ch = ' ';
     if (value < 0) {
       if (pos[0] >= text.length()) {
@@ -2170,21 +2068,18 @@ public class DateTimeFormat {
       int defaultCenturyStartYear = date.getYear() + 1900 - 80;
       int ambiguousTwoDigitYear = defaultCenturyStartYear % 100;
       cal.setAmbiguousYear(value == ambiguousTwoDigitYear);
-      value += (defaultCenturyStartYear / 100) * 100
-          + (value < ambiguousTwoDigitYear ? 100 : 0);
+      value += (defaultCenturyStartYear / 100) * 100 + (value < ambiguousTwoDigitYear ? 100 : 0);
     }
     cal.setYear(value);
     return true;
   }
 
   /**
-   * Formats a number with the specified minimum number of digits, using zero to
-   * fill the gap.
-   * 
+   * Formats a number with the specified minimum number of digits, using zero to fill the gap.
+   *
    * @param buf where zero padded string will be written to
    * @param value the number value being formatted
-   * @param minWidth minimum width of the formatted string; zero will be padded
-   *          to reach this width
+   * @param minWidth minimum width of the formatted string; zero will be padded to reach this width
    */
   private void zeroPaddingNumber(StringBuilder buf, int value, int minWidth) {
     int b = NUMBER_BASE;

--- a/gwt-datetimeformat/src/main/java/org/gwtproject/i18n/shared/TimeZone.java
+++ b/gwt-datetimeformat/src/main/java/org/gwtproject/i18n/shared/TimeZone.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2011 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -17,15 +17,12 @@ package org.gwtproject.i18n.shared;
 
 import java.util.Date;
 
-/**
- * Abstracts a GWT timezone.
- */
+/** Abstracts a GWT timezone. */
 public interface TimeZone {
 
   /**
-   * Returns the daylight savings time adjustment, in minutes, for the given
-   * date. If daylight savings time is in effect on the given date, the number
-   * will be positive, otherwise 0.
+   * Returns the daylight savings time adjustment, in minutes, for the given date. If daylight
+   * savings time is in effect on the given date, the number will be positive, otherwise 0.
    *
    * @param date the date to check
    * @return offset amount
@@ -41,9 +38,8 @@ public interface TimeZone {
   String getGMTString(Date date);
 
   /**
-   * Returns time zone id for this time zone. For time zone objects that have
-   * been instantiated from a time zone offset, the POSIX time zone id will be
-   * returned.
+   * Returns time zone id for this time zone. For time zone objects that have been instantiated from
+   * a time zone offset, the POSIX time zone id will be returned.
    *
    * @return time zone id
    */
@@ -58,9 +54,8 @@ public interface TimeZone {
   String getISOTimeZoneString(Date date);
 
   /**
-   * Returns the long version of the time zone name for the given date; the
-   * result of this method will be different if daylight savings time is in
-   * effect.
+   * Returns the long version of the time zone name for the given date; the result of this method
+   * will be different if daylight savings time is in effect.
    *
    * @param date The date for which the long time zone name is returned
    * @return long time zone name
@@ -68,17 +63,17 @@ public interface TimeZone {
   String getLongName(Date date);
 
   /**
-   * Returns the RFC representation of the time zone name for the given date.
-   * To be consistent with JDK/Javascript API, west of Greenwich will be
-   * positive.
+   * Returns the RFC representation of the time zone name for the given date. To be consistent with
+   * JDK/Javascript API, west of Greenwich will be positive.
    *
-   *  @param date The date for which time to retrieve time zone offset
-   *  @return time zone offset in minutes
+   * @param date The date for which time to retrieve time zone offset
+   * @return time zone offset in minutes
    */
   int getOffset(Date date);
 
   /**
    * To get RFC representation of certain time zone name for given date.
+   *
    * @param date The date for which time to retrieve RFC time zone string
    * @return RFC time zone string
    */
@@ -92,14 +87,11 @@ public interface TimeZone {
    */
   String getShortName(Date date);
 
-  /**
-   * Returns the standard time zone offset, in minutes.
-   */
+  /** Returns the standard time zone offset, in minutes. */
   int getStandardOffset();
 
   /**
-   * Check whether the given date and time falls within a daylight savings time
-   * period.
+   * Check whether the given date and time falls within a daylight savings time period.
    *
    * @param date and time to check
    * @return true if daylight savings time is in effect

--- a/gwt-datetimeformat/src/main/java/org/gwtproject/i18n/shared/annotations/IsCustomDateTimeFormat.java
+++ b/gwt-datetimeformat/src/main/java/org/gwtproject/i18n/shared/annotations/IsCustomDateTimeFormat.java
@@ -19,10 +19,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
-
-/**
- * Marks an interface as a custom DateTimeFormat for CustomDateTimeFormatProcessor
- */
+/** Marks an interface as a custom DateTimeFormat for CustomDateTimeFormatProcessor */
 @Documented
 @Target(ElementType.TYPE)
 public @interface IsCustomDateTimeFormat {}

--- a/gwt-datetimeformat/src/main/java/org/gwtproject/i18n/shared/impl/DateRecord.java
+++ b/gwt-datetimeformat/src/main/java/org/gwtproject/i18n/shared/impl/DateRecord.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2008 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -18,13 +18,11 @@ package org.gwtproject.i18n.shared.impl;
 import java.util.Date;
 
 /**
- * Implementation detail of DateTimeFormat -- not a public API and subject to
- * change.
- * 
- * DateRecord class exposes almost the same set of interface as Date class with
- * only a few exceptions. The main purpose is the record all the information
- * during parsing phase and resolve them in a later time when all information
- * can be processed together.
+ * Implementation detail of DateTimeFormat -- not a public API and subject to change.
+ *
+ * <p>DateRecord class exposes almost the same set of interface as Date class with only a few
+ * exceptions. The main purpose is the record all the information during parsing phase and resolve
+ * them in a later time when all information can be processed together.
  */
 @SuppressWarnings("deprecation")
 public class DateRecord extends Date {
@@ -57,8 +55,8 @@ public class DateRecord extends Date {
   private boolean ambiguousYear;
 
   /**
-   * Initialize DateExt object with default value. Here we use -1 for most of
-   * the field to indicate that field is not set.
+   * Initialize DateExt object with default value. Here we use -1 for most of the field to indicate
+   * that field is not set.
    */
   public DateRecord() {
     era = -1;
@@ -77,17 +75,15 @@ public class DateRecord extends Date {
   }
 
   /**
-   * calcDate uses all the field available so far to fill a Date object. For
-   * those information that is not provided, the existing value in 'date' will
-   * be kept. Ambiguous year will be resolved after the date/time values are
-   * resolved.
-   * 
-   * If the strict option is set to true, calcDate will calculate certain
-   * invalid dates by wrapping around as needed. For example, February 30 will
-   * wrap to March 2.
-   * 
-   * @param date The Date object being filled. Its value should be set to an
-   *          acceptable default before pass in to this method
+   * calcDate uses all the field available so far to fill a Date object. For those information that
+   * is not provided, the existing value in 'date' will be kept. Ambiguous year will be resolved
+   * after the date/time values are resolved.
+   *
+   * <p>If the strict option is set to true, calcDate will calculate certain invalid dates by
+   * wrapping around as needed. For example, February 30 will wrap to March 2.
+   *
+   * @param date The Date object being filled. Its value should be set to an acceptable default
+   *     before pass in to this method
    * @param strict true to be strict when parsing
    * @return true if successful, otherwise false.
    */
@@ -160,8 +156,7 @@ public class DateRecord extends Date {
     // We don't need to check the day of week as it is guaranteed to be correct
     // or return false below.
     if (strict) {
-      if ((this.year > Integer.MIN_VALUE)
-          && ((this.year - JS_START_YEAR) != date.getYear())) {
+      if ((this.year > Integer.MIN_VALUE) && ((this.year - JS_START_YEAR) != date.getYear())) {
         return false;
       }
       if ((this.month >= 0) && (this.month != date.getMonth())) {
@@ -238,10 +233,9 @@ public class DateRecord extends Date {
   }
 
   /**
-   * Set ambiguous year field. This flag indicates that a 2 digit years's
-   * century need to be determined by its date/time value. This can only be
-   * resolved after its date/time is known.
-   * 
+   * Set ambiguous year field. This flag indicates that a 2 digit years's century need to be
+   * determined by its date/time value. This can only be resolved after its date/time is known.
+   *
    * @param ambiguousYear true if it is ambiguous year.
    */
   public void setAmbiguousYear(boolean ambiguousYear) {
@@ -250,7 +244,7 @@ public class DateRecord extends Date {
 
   /**
    * Set morning/afternoon field.
-   * 
+   *
    * @param ampm ampm value.
    */
   public void setAmpm(int ampm) {
@@ -259,7 +253,7 @@ public class DateRecord extends Date {
 
   /**
    * Set dayOfMonth field.
-   * 
+   *
    * @param day dayOfMonth value
    */
   public void setDayOfMonth(int day) {
@@ -268,7 +262,7 @@ public class DateRecord extends Date {
 
   /**
    * Set dayOfWeek field.
-   * 
+   *
    * @param dayOfWeek day of the week.
    */
   public void setDayOfWeek(int dayOfWeek) {
@@ -277,7 +271,7 @@ public class DateRecord extends Date {
 
   /**
    * Set Era field.
-   * 
+   *
    * @param era era value being set.
    */
   public void setEra(int era) {
@@ -286,7 +280,7 @@ public class DateRecord extends Date {
 
   /**
    * Set hour field.
-   * 
+   *
    * @param hours hour value.
    */
   @Override
@@ -305,7 +299,7 @@ public class DateRecord extends Date {
 
   /**
    * Set milliseconds field.
-   * 
+   *
    * @param milliseconds milliseconds value.
    */
   public void setMilliseconds(int milliseconds) {
@@ -314,7 +308,7 @@ public class DateRecord extends Date {
 
   /**
    * Set minute field.
-   * 
+   *
    * @param minutes minute value.
    */
   @Override
@@ -324,7 +318,7 @@ public class DateRecord extends Date {
 
   /**
    * Set month field.
-   * 
+   *
    * @param month month value.
    */
   @Override
@@ -334,7 +328,7 @@ public class DateRecord extends Date {
 
   /**
    * Set seconds field.
-   * 
+   *
    * @param seconds second value.
    */
   @Override
@@ -344,7 +338,7 @@ public class DateRecord extends Date {
 
   /**
    * Set timezone offset, in minutes.
-   * 
+   *
    * @param tzOffset timezone offset.
    */
   public void setTzOffset(int tzOffset) {
@@ -353,7 +347,7 @@ public class DateRecord extends Date {
 
   /**
    * Set year field.
-   * 
+   *
    * @param value year value.
    */
   @Override

--- a/gwt-datetimeformat/src/test/java/org/gwtproject/i18n/client/DateTimeFormat_de_Test.java
+++ b/gwt-datetimeformat/src/test/java/org/gwtproject/i18n/client/DateTimeFormat_de_Test.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -15,14 +15,10 @@
  */
 package org.gwtproject.i18n.client;
 
+import java.util.Date;
 import org.gwtproject.i18n.shared.DateTimeFormatTestBase;
 
-import java.util.Date;
-
-/**
- * Tests formatting functionality in {@link DateTimeFormat} for the German
- * language.
- */
+/** Tests formatting functionality in {@link DateTimeFormat} for the German language. */
 @SuppressWarnings("deprecation")
 public class DateTimeFormat_de_Test extends DateTimeFormatTestBase {
 
@@ -33,14 +29,13 @@ public class DateTimeFormat_de_Test extends DateTimeFormatTestBase {
 
   public void test_EEEEMMMddyy() {
     Date date = new Date(2006 - 1900, 6, 27, 13, 10, 10);
-    assertEquals("Donnerstag,Juli 27, 2006", DateTimeFormat.getFormat(
-        "EEEE,MMMM dd, yyyy").format(date));
+    assertEquals(
+        "Donnerstag,Juli 27, 2006", DateTimeFormat.getFormat("EEEE,MMMM dd, yyyy").format(date));
   }
 
   public void test_EEEMMMddyy() {
     Date date = new Date(2006 - 1900, 6, 27, 13, 10, 10);
-    assertEquals("Do., Juli 27, 06",
-        DateTimeFormat.getFormat("EEE, MMM d, yy").format(date));
+    assertEquals("Do., Juli 27, 06", DateTimeFormat.getFormat("EEE, MMM d, yy").format(date));
   }
 
   public void test_HHmmss() {
@@ -50,8 +45,7 @@ public class DateTimeFormat_de_Test extends DateTimeFormatTestBase {
 
   public void test_hhmmssa() {
     Date date = new Date(2006 - 1900, 6, 27, 13, 10, 10);
-    assertEquals("1:10:10 PM",
-        DateTimeFormat.getFormat("h:mm:ss a").format(date));
+    assertEquals("1:10:10 PM", DateTimeFormat.getFormat("h:mm:ss a").format(date));
   }
 
   public void test_predefinedFormat() {
@@ -86,52 +80,40 @@ public class DateTimeFormat_de_Test extends DateTimeFormatTestBase {
     Date date;
 
     date = new Date(2006 - 1900, 0, 27, 13, 10, 10);
-    assertEquals("1. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("1. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 1, 27, 13, 10, 10);
-    assertEquals("1. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("1. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 2, 27, 13, 10, 10);
-    assertEquals("1. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("1. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 3, 27, 13, 10, 10);
-    assertEquals("2. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("2. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 4, 27, 13, 10, 10);
-    assertEquals("2. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("2. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 5, 27, 13, 10, 10);
-    assertEquals("2. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("2. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 6, 27, 13, 10, 10);
-    assertEquals("3. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("3. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 7, 27, 13, 10, 10);
-    assertEquals("3. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("3. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 8, 27, 13, 10, 10);
-    assertEquals("3. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("3. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 9, 27, 13, 10, 10);
-    assertEquals("4. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("4. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 10, 27, 13, 10, 10);
-    assertEquals("4. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("4. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 11, 27, 13, 10, 10);
-    assertEquals("4. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("4. Quartal 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
   }
 
   public void test_QQyyyy() {
@@ -202,22 +184,21 @@ public class DateTimeFormat_de_Test extends DateTimeFormatTestBase {
     date.setHours(13);
     date.setMinutes(10);
     date.setSeconds(10);
-    assertEquals("13 o'clock",
-        DateTimeFormat.getFormat("HH 'o''clock'").format(date));
-    assertEquals("13 oclock", DateTimeFormat.getFormat("HH 'oclock'").format(
-        date));
+    assertEquals("13 o'clock", DateTimeFormat.getFormat("HH 'o''clock'").format(date));
+    assertEquals("13 oclock", DateTimeFormat.getFormat("HH 'oclock'").format(date));
     assertEquals("13 '", DateTimeFormat.getFormat("HH ''").format(date));
   }
 
   public void test_yyyyyMMMMM() {
     Date date = new Date(2006 - 1900, 6, 27, 13, 10, 10);
-    assertEquals("02006.J.27 n. Chr. 01:10 PM", DateTimeFormat.getFormat(
-        "yyyyy.MMMMM.dd GGG hh:mm aaa").format(date));
+    assertEquals(
+        "02006.J.27 n. Chr. 01:10 PM",
+        DateTimeFormat.getFormat("yyyyy.MMMMM.dd GGG hh:mm aaa").format(date));
   }
 
-//  public void testMessageDateTime() {
-//    MyMessages m = GWT.create(MyMessages.class);
-//    Date d = new Date(2010 - 1900, 1, 15, 12, 0, 0);
-//    assertEquals("Es ist 15. Feb. 2010", m.getCustomizedDate(d));
-//  }
+  //  public void testMessageDateTime() {
+  //    MyMessages m = GWT.create(MyMessages.class);
+  //    Date d = new Date(2010 - 1900, 1, 15, 12, 0, 0);
+  //    assertEquals("Es ist 15. Feb. 2010", m.getCustomizedDate(d));
+  //  }
 }

--- a/gwt-datetimeformat/src/test/java/org/gwtproject/i18n/client/DateTimeFormat_en_Test.java
+++ b/gwt-datetimeformat/src/test/java/org/gwtproject/i18n/client/DateTimeFormat_en_Test.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2008 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -15,12 +15,10 @@
  */
 package org.gwtproject.i18n.client;
 
-import com.google.gwt.core.client.GWT;
-//import org.gwtproject.i18n.client.constants.TimeZoneConstants;
+// import org.gwtproject.i18n.client.constants.TimeZoneConstants;
+import java.util.Date;
 import org.gwtproject.i18n.client.impl.cldr.DateTimeFormatInfoImpl_de;
 import org.gwtproject.i18n.shared.DateTimeFormatTestBase;
-
-import java.util.Date;
 
 /**
  * Tests formatting functionality in {@link org.gwtproject.i18n.shared.DateTimeFormat} for the
@@ -60,64 +58,59 @@ public class DateTimeFormat_en_Test extends DateTimeFormatTestBase {
     assertEquals("T", DateTimeFormat.getFormat("ccccc").format(date));
   }
 
-//  public void test_daylightTimeTransition() {
-//    // US PST transitioned to PDT on 2006/4/2 2:00am, jump to 2006/4/2 3:00am.
-//    // That's UTC time 2006/4/2 10:00am
-//
-//    TimeZoneConstants timeZoneData = GWT.create(TimeZoneConstants.class);
-//    String str = timeZoneData.americaLosAngeles();
-//    TimeZone usPacific = TimeZone.createTimeZone(str);
-//
-//    Date date = new Date();
-//    date.setTime(Date.UTC(2006 - 1900, 3, 2, 9, 59, 0));
-//    assertEquals("04/02/2006 01:59:00 PST", DateTimeFormat.getFormat(
-//        "MM/dd/yyyy HH:mm:ss z").format(date, usPacific));
-//    date.setTime(Date.UTC(2006 - 1900, 3, 2, 10, 01, 0));
-//    assertEquals("04/02/2006 03:01:00 PDT", DateTimeFormat.getFormat(
-//        "MM/dd/yyyy HH:mm:ss z").format(date, usPacific));
-//    date.setTime(Date.UTC(2006 - 1900, 3, 2, 10, 0, 0));
-//    assertEquals("04/02/2006 03:00:00 PDT", DateTimeFormat.getFormat(
-//        "MM/dd/yyyy HH:mm:ss z").format(date, usPacific));
-//
-//    // US PDT transition to PST on 2006/10/29 2:00am, jump back to PDT
-//    // 2006/4/2 1:00am
-//    date.setTime(Date.UTC(2006 - 1900, 10 - 1, 29, 8, 59, 0));
-//    assertEquals("10/29/2006 01:59:00 PDT", DateTimeFormat.getFormat(
-//        "MM/dd/yyyy HH:mm:ss z").format(date, usPacific));
-//    date.setTime(Date.UTC(2006 - 1900, 10 - 1, 29, 9, 01, 0));
-//    assertEquals("10/29/2006 01:01:00 PST", DateTimeFormat.getFormat(
-//        "MM/dd/yyyy HH:mm:ss z").format(date, usPacific));
-//    date.setTime(Date.UTC(2006 - 1900, 10 - 1, 29, 9, 0, 0));
-//    assertEquals("10/29/2006 01:00:00 PST", DateTimeFormat.getFormat(
-//        "MM/dd/yyyy HH:mm:ss z").format(date, usPacific));
-//  }
+  //  public void test_daylightTimeTransition() {
+  //    // US PST transitioned to PDT on 2006/4/2 2:00am, jump to 2006/4/2 3:00am.
+  //    // That's UTC time 2006/4/2 10:00am
+  //
+  //    TimeZoneConstants timeZoneData = GWT.create(TimeZoneConstants.class);
+  //    String str = timeZoneData.americaLosAngeles();
+  //    TimeZone usPacific = TimeZone.createTimeZone(str);
+  //
+  //    Date date = new Date();
+  //    date.setTime(Date.UTC(2006 - 1900, 3, 2, 9, 59, 0));
+  //    assertEquals("04/02/2006 01:59:00 PST", DateTimeFormat.getFormat(
+  //        "MM/dd/yyyy HH:mm:ss z").format(date, usPacific));
+  //    date.setTime(Date.UTC(2006 - 1900, 3, 2, 10, 01, 0));
+  //    assertEquals("04/02/2006 03:01:00 PDT", DateTimeFormat.getFormat(
+  //        "MM/dd/yyyy HH:mm:ss z").format(date, usPacific));
+  //    date.setTime(Date.UTC(2006 - 1900, 3, 2, 10, 0, 0));
+  //    assertEquals("04/02/2006 03:00:00 PDT", DateTimeFormat.getFormat(
+  //        "MM/dd/yyyy HH:mm:ss z").format(date, usPacific));
+  //
+  //    // US PDT transition to PST on 2006/10/29 2:00am, jump back to PDT
+  //    // 2006/4/2 1:00am
+  //    date.setTime(Date.UTC(2006 - 1900, 10 - 1, 29, 8, 59, 0));
+  //    assertEquals("10/29/2006 01:59:00 PDT", DateTimeFormat.getFormat(
+  //        "MM/dd/yyyy HH:mm:ss z").format(date, usPacific));
+  //    date.setTime(Date.UTC(2006 - 1900, 10 - 1, 29, 9, 01, 0));
+  //    assertEquals("10/29/2006 01:01:00 PST", DateTimeFormat.getFormat(
+  //        "MM/dd/yyyy HH:mm:ss z").format(date, usPacific));
+  //    date.setTime(Date.UTC(2006 - 1900, 10 - 1, 29, 9, 0, 0));
+  //    assertEquals("10/29/2006 01:00:00 PST", DateTimeFormat.getFormat(
+  //        "MM/dd/yyyy HH:mm:ss z").format(date, usPacific));
+  //  }
 
   public void test_EEEEMMMddHHmmsszzzyy() {
     DateTimeFormat dtf = DateTimeFormat.getFormat("EEE MMM dd HH:mm:ss zzz yyyy");
     Date date = dtf.parse("Mon Aug 30 00:45:00 GMT 2010");
-    assertEquals(45, (date.getHours() * 60 + date.getMinutes()
-        + date.getTimezoneOffset()) % 1440);
+    assertEquals(45, (date.getHours() * 60 + date.getMinutes() + date.getTimezoneOffset()) % 1440);
     date = dtf.parse("Mon Aug 30 01:45:00 GMT 2010");
-    assertEquals(105, (date.getHours() * 60 + date.getMinutes()
-        + date.getTimezoneOffset()) % 1440);
+    assertEquals(105, (date.getHours() * 60 + date.getMinutes() + date.getTimezoneOffset()) % 1440);
     date = dtf.parse("Mon Aug 30 06:45:00 GMT 2010");
-    assertEquals(405, (date.getHours() * 60 + date.getMinutes()
-        + date.getTimezoneOffset()) % 1440);
+    assertEquals(405, (date.getHours() * 60 + date.getMinutes() + date.getTimezoneOffset()) % 1440);
     date = dtf.parse("Mon Aug 30 07:45:00 GMT 2010");
-    assertEquals(465, (date.getHours() * 60 + date.getMinutes()
-        + date.getTimezoneOffset()) % 1440);
+    assertEquals(465, (date.getHours() * 60 + date.getMinutes() + date.getTimezoneOffset()) % 1440);
   }
 
   public void test_EEEEMMMddyy() {
     Date date = new Date(2006 - 1900, 6, 27, 13, 10, 10);
-    assertEquals("Thursday,July 27, 2006", DateTimeFormat.getFormat(
-        "EEEE,MMMM dd, yyyy").format(date));
+    assertEquals(
+        "Thursday,July 27, 2006", DateTimeFormat.getFormat("EEEE,MMMM dd, yyyy").format(date));
   }
 
   public void test_EEEMMMddyy() {
     Date date = new Date(2006 - 1900, 6, 27, 13, 10, 10);
-    assertEquals("Thu, Jul 27, 06",
-        DateTimeFormat.getFormat("EEE, MMM d, yy").format(date));
+    assertEquals("Thu, Jul 27, 06", DateTimeFormat.getFormat("EEE, MMM d, yy").format(date));
   }
 
   public void test_HHmmss() {
@@ -127,8 +120,7 @@ public class DateTimeFormat_en_Test extends DateTimeFormatTestBase {
 
   public void test_hhmmssa() {
     Date date = new Date(2006 - 1900, 6, 27, 13, 10, 10);
-    assertEquals("1:10:10 PM", DateTimeFormat.getFormat("h:mm:ss a").format(
-        date));
+    assertEquals("1:10:10 PM", DateTimeFormat.getFormat("h:mm:ss a").format(date));
   }
 
   public void test_k() {
@@ -162,105 +154,93 @@ public class DateTimeFormat_en_Test extends DateTimeFormatTestBase {
     assertEquals("J", DateTimeFormat.getFormat("LLLLL").format(date));
   }
 
-//  public void test_predefinedFormat() {
-//    Date date = new Date(2006 - 1900, 7, 4, 13, 49, 24);
-//
-//    TimeZoneConstants timeZoneData = GWT.create(TimeZoneConstants.class);
-//    String str = timeZoneData.americaLosAngeles();
-//    TimeZone usPacific = TimeZone.createTimeZone(TimeZoneInfo.buildTimeZoneData(str));
-//
-//    String fullDateFormat = DateTimeFormat.getFullDateFormat().format(date);
-//    assertEquals("Friday, August 4, 2006", fullDateFormat);
-//
-//    String longDateFormat = DateTimeFormat.getLongDateFormat().format(date);
-//    assertEquals("August 4, 2006", longDateFormat);
-//
-//    String medDateFormat = DateTimeFormat.getMediumDateFormat().format(date);
-//    assertEquals("Aug 4, 2006", medDateFormat);
-//
-//    String shortDateFormat = DateTimeFormat.getShortDateFormat().format(date);
-//    assertEquals("8/4/06", shortDateFormat);
-//
-//    // When dealing with time zone, better use UTC time.
-//    // And when UTC time is used, time zone must be given in "format".
-//    date.setTime(Date.UTC(2006 - 1900, 7, 4, 20, 49, 24));
-//    String fullTimeFormat = DateTimeFormat.getFullTimeFormat().format(date,
-//        usPacific);
-//    assertEquals("1:49:24 PM Pacific Daylight Time", fullTimeFormat);
-//
-//    String longTimeFormat = DateTimeFormat.getLongTimeFormat().format(date,
-//        usPacific);
-//    assertEquals("1:49:24 PM PDT", longTimeFormat);
-//
-//    String medTimeFormat = DateTimeFormat.getMediumTimeFormat().format(date,
-//        usPacific);
-//    assertEquals("1:49:24 PM", medTimeFormat);
-//
-//    String shortTimeFormat = DateTimeFormat.getShortTimeFormat().format(date,
-//        usPacific);
-//    assertEquals("1:49 PM", shortTimeFormat);
-//
-//    String medFormat = DateTimeFormat.getMediumDateTimeFormat().format(date,
-//        usPacific);
-//    assertEquals("Aug 4, 2006, 1:49:24 PM", medFormat);
-//
-//    String shortFormat = DateTimeFormat.getShortDateTimeFormat().format(date,
-//        usPacific);
-//    assertEquals("8/4/06, 1:49 PM", shortFormat);
-//  }
-  
+  //  public void test_predefinedFormat() {
+  //    Date date = new Date(2006 - 1900, 7, 4, 13, 49, 24);
+  //
+  //    TimeZoneConstants timeZoneData = GWT.create(TimeZoneConstants.class);
+  //    String str = timeZoneData.americaLosAngeles();
+  //    TimeZone usPacific = TimeZone.createTimeZone(TimeZoneInfo.buildTimeZoneData(str));
+  //
+  //    String fullDateFormat = DateTimeFormat.getFullDateFormat().format(date);
+  //    assertEquals("Friday, August 4, 2006", fullDateFormat);
+  //
+  //    String longDateFormat = DateTimeFormat.getLongDateFormat().format(date);
+  //    assertEquals("August 4, 2006", longDateFormat);
+  //
+  //    String medDateFormat = DateTimeFormat.getMediumDateFormat().format(date);
+  //    assertEquals("Aug 4, 2006", medDateFormat);
+  //
+  //    String shortDateFormat = DateTimeFormat.getShortDateFormat().format(date);
+  //    assertEquals("8/4/06", shortDateFormat);
+  //
+  //    // When dealing with time zone, better use UTC time.
+  //    // And when UTC time is used, time zone must be given in "format".
+  //    date.setTime(Date.UTC(2006 - 1900, 7, 4, 20, 49, 24));
+  //    String fullTimeFormat = DateTimeFormat.getFullTimeFormat().format(date,
+  //        usPacific);
+  //    assertEquals("1:49:24 PM Pacific Daylight Time", fullTimeFormat);
+  //
+  //    String longTimeFormat = DateTimeFormat.getLongTimeFormat().format(date,
+  //        usPacific);
+  //    assertEquals("1:49:24 PM PDT", longTimeFormat);
+  //
+  //    String medTimeFormat = DateTimeFormat.getMediumTimeFormat().format(date,
+  //        usPacific);
+  //    assertEquals("1:49:24 PM", medTimeFormat);
+  //
+  //    String shortTimeFormat = DateTimeFormat.getShortTimeFormat().format(date,
+  //        usPacific);
+  //    assertEquals("1:49 PM", shortTimeFormat);
+  //
+  //    String medFormat = DateTimeFormat.getMediumDateTimeFormat().format(date,
+  //        usPacific);
+  //    assertEquals("Aug 4, 2006, 1:49:24 PM", medFormat);
+  //
+  //    String shortFormat = DateTimeFormat.getShortDateTimeFormat().format(date,
+  //        usPacific);
+  //    assertEquals("8/4/06, 1:49 PM", shortFormat);
+  //  }
+
   public void test_QQQQyy() {
     Date date;
 
     date = new Date(2006 - 1900, 0, 27, 13, 10, 10);
-    assertEquals("1st quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("1st quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 1, 27, 13, 10, 10);
-    assertEquals("1st quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("1st quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 2, 27, 13, 10, 10);
-    assertEquals("1st quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("1st quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 3, 27, 13, 10, 10);
-    assertEquals("2nd quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("2nd quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 4, 27, 13, 10, 10);
-    assertEquals("2nd quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("2nd quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 5, 27, 13, 10, 10);
-    assertEquals("2nd quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("2nd quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 6, 27, 13, 10, 10);
-    assertEquals("3rd quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("3rd quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 7, 27, 13, 10, 10);
-    assertEquals("3rd quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("3rd quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 8, 27, 13, 10, 10);
-    assertEquals("3rd quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("3rd quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 9, 27, 13, 10, 10);
-    assertEquals("4th quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("4th quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 10, 27, 13, 10, 10);
-    assertEquals("4th quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("4th quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
 
     date = new Date(2006 - 1900, 11, 27, 13, 10, 10);
-    assertEquals("4th quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(
-        date));
+    assertEquals("4th quarter 06", DateTimeFormat.getFormat("QQQQ yy").format(date));
   }
-  
+
   public void test_QQyyyy() {
     Date date = new Date(2006 - 1900, 0, 27);
     date.setHours(13);
@@ -323,29 +303,27 @@ public class DateTimeFormat_en_Test extends DateTimeFormatTestBase {
     date.setSeconds(10);
     assertEquals("Q4 2006", DateTimeFormat.getFormat("QQ yyyy").format(date));
   }
-  
+
   public void test_quote() {
     Date date = new Date(2006 - 1900, 6, 27);
     date.setHours(13);
     date.setMinutes(10);
     date.setSeconds(10);
-    assertEquals("13 o'clock",
-        DateTimeFormat.getFormat("HH 'o''clock'").format(date));
-    assertEquals("13 oclock", DateTimeFormat.getFormat("HH 'oclock'").format(
-        date));
+    assertEquals("13 o'clock", DateTimeFormat.getFormat("HH 'o''clock'").format(date));
+    assertEquals("13 oclock", DateTimeFormat.getFormat("HH 'oclock'").format(date));
     assertEquals("13 '", DateTimeFormat.getFormat("HH ''").format(date));
   }
 
   public void test_S() {
     Date date = new Date(0);
     assertEquals("0", DateTimeFormat.getFormat("S").format(date));
-    
+
     date = new Date(55);
     assertEquals("1", DateTimeFormat.getFormat("S").format(date));
-    
+
     date = new Date(555);
     assertEquals("6", DateTimeFormat.getFormat("S").format(date));
-    
+
     date = new Date(999);
     assertEquals("9", DateTimeFormat.getFormat("S").format(date));
   }
@@ -356,17 +334,21 @@ public class DateTimeFormat_en_Test extends DateTimeFormatTestBase {
     Date date = new Date();
     date.setTime(Date.UTC(2006 - 1900, 6, 27, 14, 10, 10));
 
-    assertEquals("07/27/2006 06:10:10 Etc/GMT+8", DateTimeFormat.getFormat(
-        "MM/dd/yyyy HH:mm:ss v").format(date, simpleTimeZone));
+    assertEquals(
+        "07/27/2006 06:10:10 Etc/GMT+8",
+        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss v").format(date, simpleTimeZone));
 
-    assertEquals("07/27/2006 06:10:10 Etc/GMT+8", DateTimeFormat.getFormat(
-        "MM/dd/yyyy HH:mm:ss vv").format(date, simpleTimeZone));
+    assertEquals(
+        "07/27/2006 06:10:10 Etc/GMT+8",
+        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss vv").format(date, simpleTimeZone));
 
-    assertEquals("07/27/2006 06:10:10 Etc/GMT+8", DateTimeFormat.getFormat(
-        "MM/dd/yyyy HH:mm:ss vvv").format(date, simpleTimeZone));
+    assertEquals(
+        "07/27/2006 06:10:10 Etc/GMT+8",
+        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss vvv").format(date, simpleTimeZone));
 
-    assertEquals("07/27/2006 06:10:10 Etc/GMT+8", DateTimeFormat.getFormat(
-        "MM/dd/yyyy HH:mm:ss vvvv").format(date, simpleTimeZone));
+    assertEquals(
+        "07/27/2006 06:10:10 Etc/GMT+8",
+        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss vvvv").format(date, simpleTimeZone));
   }
 
   public void test_simpleTimezonez() {
@@ -374,17 +356,21 @@ public class DateTimeFormat_en_Test extends DateTimeFormatTestBase {
     Date date = new Date();
     date.setTime(Date.UTC(2006 - 1900, 6, 27, 13, 10, 10));
 
-    assertEquals("07/27/2006 06:10:10 UTC-7", DateTimeFormat.getFormat(
-        "MM/dd/yyyy HH:mm:ss z").format(date, simpleTimeZone));
+    assertEquals(
+        "07/27/2006 06:10:10 UTC-7",
+        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss z").format(date, simpleTimeZone));
 
-    assertEquals("07/27/2006 06:10:10 UTC-7", DateTimeFormat.getFormat(
-        "MM/dd/yyyy HH:mm:ss zz").format(date, simpleTimeZone));
+    assertEquals(
+        "07/27/2006 06:10:10 UTC-7",
+        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss zz").format(date, simpleTimeZone));
 
-    assertEquals("07/27/2006 06:10:10 UTC-7", DateTimeFormat.getFormat(
-        "MM/dd/yyyy HH:mm:ss zzz").format(date, simpleTimeZone));
+    assertEquals(
+        "07/27/2006 06:10:10 UTC-7",
+        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss zzz").format(date, simpleTimeZone));
 
-    assertEquals("07/27/2006 06:10:10 UTC-7", DateTimeFormat.getFormat(
-        "MM/dd/yyyy HH:mm:ss zzzz").format(date, simpleTimeZone));
+    assertEquals(
+        "07/27/2006 06:10:10 UTC-7",
+        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss zzzz").format(date, simpleTimeZone));
   }
 
   public void test_simpleTimezoneZ() {
@@ -392,158 +378,163 @@ public class DateTimeFormat_en_Test extends DateTimeFormatTestBase {
     Date date = new Date();
     date.setTime(Date.UTC(2006 - 1900, 6, 27, 13, 10, 10));
 
-    assertEquals("07/27/2006 06:10:10 -0700", DateTimeFormat.getFormat(
-        "MM/dd/yyyy HH:mm:ss Z").format(date, simpleTimeZone));
+    assertEquals(
+        "07/27/2006 06:10:10 -0700",
+        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss Z").format(date, simpleTimeZone));
 
-    assertEquals("07/27/2006 06:10:10 -0700", DateTimeFormat.getFormat(
-        "MM/dd/yyyy HH:mm:ss ZZ").format(date, simpleTimeZone));
+    assertEquals(
+        "07/27/2006 06:10:10 -0700",
+        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss ZZ").format(date, simpleTimeZone));
 
-    assertEquals("07/27/2006 06:10:10 -07:00", DateTimeFormat.getFormat(
-        "MM/dd/yyyy HH:mm:ss ZZZ").format(date, simpleTimeZone));
+    assertEquals(
+        "07/27/2006 06:10:10 -07:00",
+        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss ZZZ").format(date, simpleTimeZone));
 
-    assertEquals("07/27/2006 06:10:10 GMT-07:00", DateTimeFormat.getFormat(
-        "MM/dd/yyyy HH:mm:ss ZZZZ").format(date, simpleTimeZone));
+    assertEquals(
+        "07/27/2006 06:10:10 GMT-07:00",
+        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss ZZZZ").format(date, simpleTimeZone));
   }
 
   public void test_SS() {
     Date date = new Date(0);
     assertEquals("00", DateTimeFormat.getFormat("SS").format(date));
-    
+
     date = new Date(55);
     assertEquals("06", DateTimeFormat.getFormat("SS").format(date));
-    
+
     date = new Date(555);
     assertEquals("56", DateTimeFormat.getFormat("SS").format(date));
-    
+
     date = new Date(999);
     assertEquals("99", DateTimeFormat.getFormat("SS").format(date));
   }
 
-  public void test_SSS() {    
+  public void test_SSS() {
     Date date = new Date(0);
     assertEquals("000", DateTimeFormat.getFormat("SSS").format(date));
-    
+
     date = new Date(55);
     assertEquals("055", DateTimeFormat.getFormat("SSS").format(date));
-    
+
     date = new Date(555);
     assertEquals("555", DateTimeFormat.getFormat("SSS").format(date));
-    
+
     date = new Date(999);
     assertEquals("999", DateTimeFormat.getFormat("SSS").format(date));
   }
 
-//  public void test_timezonev() {
-//    TimeZoneConstants timeZoneData = GWT.create(TimeZoneConstants.class);
-//    String str = timeZoneData.americaLosAngeles();
-//    TimeZone usPacific = TimeZone.createTimeZone(str);
-//
-//    Date date = new Date();
-//    date.setTime(Date.UTC(2006 - 1900, 6, 27, 13, 10, 10));
-//
-//    assertEquals("07/27/2006 06:10:10 America/Los_Angeles",
-//        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss v").format(date,
-//            usPacific));
-//
-//    assertEquals("07/27/2006 06:10:10 America/Los_Angeles",
-//        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss vv").format(date,
-//            usPacific));
-//
-//    assertEquals("07/27/2006 06:10:10 America/Los_Angeles",
-//        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss vvv").format(date,
-//            usPacific));
-//
-//    assertEquals("07/27/2006 06:10:10 America/Los_Angeles",
-//        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss vvvv").format(date,
-//            usPacific));
-//  }
+  //  public void test_timezonev() {
+  //    TimeZoneConstants timeZoneData = GWT.create(TimeZoneConstants.class);
+  //    String str = timeZoneData.americaLosAngeles();
+  //    TimeZone usPacific = TimeZone.createTimeZone(str);
+  //
+  //    Date date = new Date();
+  //    date.setTime(Date.UTC(2006 - 1900, 6, 27, 13, 10, 10));
+  //
+  //    assertEquals("07/27/2006 06:10:10 America/Los_Angeles",
+  //        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss v").format(date,
+  //            usPacific));
+  //
+  //    assertEquals("07/27/2006 06:10:10 America/Los_Angeles",
+  //        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss vv").format(date,
+  //            usPacific));
+  //
+  //    assertEquals("07/27/2006 06:10:10 America/Los_Angeles",
+  //        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss vvv").format(date,
+  //            usPacific));
+  //
+  //    assertEquals("07/27/2006 06:10:10 America/Los_Angeles",
+  //        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss vvvv").format(date,
+  //            usPacific));
+  //  }
 
-//  public void test_timezonez() {
-//    TimeZoneConstants timeZoneData = GWT.create(TimeZoneConstants.class);
-//    String str = timeZoneData.americaLosAngeles();
-//    TimeZone usPacific = TimeZone.createTimeZone(str);
-//
-//    Date date = new Date();
-//    date.setTime(Date.UTC(2006 - 1900, 6, 27, 13, 10, 10));
-//
-//    assertEquals("07/27/2006 06:10:10 PDT", DateTimeFormat.getFormat(
-//        "MM/dd/yyyy HH:mm:ss z").format(date, usPacific));
-//
-//    assertEquals("07/27/2006 06:10:10 PDT", DateTimeFormat.getFormat(
-//        "MM/dd/yyyy HH:mm:ss zz").format(date, usPacific));
-//
-//    assertEquals("07/27/2006 06:10:10 PDT", DateTimeFormat.getFormat(
-//        "MM/dd/yyyy HH:mm:ss zzz").format(date, usPacific));
-//
-//    assertEquals("07/27/2006 06:10:10 Pacific Daylight Time",
-//        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss zzzz").format(date,
-//            usPacific));
-//
-//    date.setTime(Date.UTC(2006 - 1900, 1, 27, 13, 10, 10));
-//    assertEquals("02/27/2006 05:10:10 PST", DateTimeFormat.getFormat(
-//        "MM/dd/yyyy HH:mm:ss z").format(date, usPacific));
-//
-//    assertEquals("02/27/2006 05:10:10 PST", DateTimeFormat.getFormat(
-//        "MM/dd/yyyy HH:mm:ss zz").format(date, usPacific));
-//
-//    assertEquals("02/27/2006 05:10:10 PST", DateTimeFormat.getFormat(
-//        "MM/dd/yyyy HH:mm:ss zzz").format(date, usPacific));
-//
-//    assertEquals("02/27/2006 05:10:10 Pacific Standard Time",
-//        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss zzzz").format(date,
-//            usPacific));
-//
-//    // test that we can reparse the formatted output
-//    DateTimeFormat format = DateTimeFormat.getFormat("MMM d, yyyy h:mm:ss a z");
-//    assertEquals(date, format.parse(format.format(date)));
-//  }
+  //  public void test_timezonez() {
+  //    TimeZoneConstants timeZoneData = GWT.create(TimeZoneConstants.class);
+  //    String str = timeZoneData.americaLosAngeles();
+  //    TimeZone usPacific = TimeZone.createTimeZone(str);
+  //
+  //    Date date = new Date();
+  //    date.setTime(Date.UTC(2006 - 1900, 6, 27, 13, 10, 10));
+  //
+  //    assertEquals("07/27/2006 06:10:10 PDT", DateTimeFormat.getFormat(
+  //        "MM/dd/yyyy HH:mm:ss z").format(date, usPacific));
+  //
+  //    assertEquals("07/27/2006 06:10:10 PDT", DateTimeFormat.getFormat(
+  //        "MM/dd/yyyy HH:mm:ss zz").format(date, usPacific));
+  //
+  //    assertEquals("07/27/2006 06:10:10 PDT", DateTimeFormat.getFormat(
+  //        "MM/dd/yyyy HH:mm:ss zzz").format(date, usPacific));
+  //
+  //    assertEquals("07/27/2006 06:10:10 Pacific Daylight Time",
+  //        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss zzzz").format(date,
+  //            usPacific));
+  //
+  //    date.setTime(Date.UTC(2006 - 1900, 1, 27, 13, 10, 10));
+  //    assertEquals("02/27/2006 05:10:10 PST", DateTimeFormat.getFormat(
+  //        "MM/dd/yyyy HH:mm:ss z").format(date, usPacific));
+  //
+  //    assertEquals("02/27/2006 05:10:10 PST", DateTimeFormat.getFormat(
+  //        "MM/dd/yyyy HH:mm:ss zz").format(date, usPacific));
+  //
+  //    assertEquals("02/27/2006 05:10:10 PST", DateTimeFormat.getFormat(
+  //        "MM/dd/yyyy HH:mm:ss zzz").format(date, usPacific));
+  //
+  //    assertEquals("02/27/2006 05:10:10 Pacific Standard Time",
+  //        DateTimeFormat.getFormat("MM/dd/yyyy HH:mm:ss zzzz").format(date,
+  //            usPacific));
+  //
+  //    // test that we can reparse the formatted output
+  //    DateTimeFormat format = DateTimeFormat.getFormat("MMM d, yyyy h:mm:ss a z");
+  //    assertEquals(date, format.parse(format.format(date)));
+  //  }
 
-//  public void test_timezoneZ() {
-//    TimeZoneConstants timeZoneData = GWT.create(TimeZoneConstants.class);
-//    String str = timeZoneData.americaLosAngeles();
-//    TimeZone usPacific = TimeZone.createTimeZone(str);
-//
-//    Date date = new Date();
-//    date.setTime(Date.UTC(2006 - 1900, 6, 27, 13, 10, 10));
-//
-//    assertEquals("07/27/2006 06:10:10 -0700", DateTimeFormat.getFormat(
-//        "MM/dd/yyyy HH:mm:ss Z").format(date, usPacific));
-//
-//    assertEquals("07/27/2006 06:10:10 -0700", DateTimeFormat.getFormat(
-//        "MM/dd/yyyy HH:mm:ss ZZ").format(date, usPacific));
-//
-//    assertEquals("07/27/2006 06:10:10 -07:00", DateTimeFormat.getFormat(
-//        "MM/dd/yyyy HH:mm:ss ZZZ").format(date, usPacific));
-//
-//    assertEquals("07/27/2006 06:10:10 GMT-07:00", DateTimeFormat.getFormat(
-//        "MM/dd/yyyy HH:mm:ss ZZZZ").format(date, usPacific));
-//
-//    date.setTime(Date.UTC(2006 - 1900, 1, 27, 13, 10, 10));
-//    assertEquals("02/27/2006 05:10:10 -0800", DateTimeFormat.getFormat(
-//        "MM/dd/yyyy HH:mm:ss Z").format(date, usPacific));
-//
-//    assertEquals("02/27/2006 05:10:10 -0800", DateTimeFormat.getFormat(
-//        "MM/dd/yyyy HH:mm:ss ZZ").format(date, usPacific));
-//
-//    assertEquals("02/27/2006 05:10:10 -08:00", DateTimeFormat.getFormat(
-//        "MM/dd/yyyy HH:mm:ss ZZZ").format(date, usPacific));
-//
-//    assertEquals("02/27/2006 05:10:10 GMT-08:00", DateTimeFormat.getFormat(
-//        "MM/dd/yyyy HH:mm:ss ZZZZ").format(date, usPacific));
-//  }
+  //  public void test_timezoneZ() {
+  //    TimeZoneConstants timeZoneData = GWT.create(TimeZoneConstants.class);
+  //    String str = timeZoneData.americaLosAngeles();
+  //    TimeZone usPacific = TimeZone.createTimeZone(str);
+  //
+  //    Date date = new Date();
+  //    date.setTime(Date.UTC(2006 - 1900, 6, 27, 13, 10, 10));
+  //
+  //    assertEquals("07/27/2006 06:10:10 -0700", DateTimeFormat.getFormat(
+  //        "MM/dd/yyyy HH:mm:ss Z").format(date, usPacific));
+  //
+  //    assertEquals("07/27/2006 06:10:10 -0700", DateTimeFormat.getFormat(
+  //        "MM/dd/yyyy HH:mm:ss ZZ").format(date, usPacific));
+  //
+  //    assertEquals("07/27/2006 06:10:10 -07:00", DateTimeFormat.getFormat(
+  //        "MM/dd/yyyy HH:mm:ss ZZZ").format(date, usPacific));
+  //
+  //    assertEquals("07/27/2006 06:10:10 GMT-07:00", DateTimeFormat.getFormat(
+  //        "MM/dd/yyyy HH:mm:ss ZZZZ").format(date, usPacific));
+  //
+  //    date.setTime(Date.UTC(2006 - 1900, 1, 27, 13, 10, 10));
+  //    assertEquals("02/27/2006 05:10:10 -0800", DateTimeFormat.getFormat(
+  //        "MM/dd/yyyy HH:mm:ss Z").format(date, usPacific));
+  //
+  //    assertEquals("02/27/2006 05:10:10 -0800", DateTimeFormat.getFormat(
+  //        "MM/dd/yyyy HH:mm:ss ZZ").format(date, usPacific));
+  //
+  //    assertEquals("02/27/2006 05:10:10 -08:00", DateTimeFormat.getFormat(
+  //        "MM/dd/yyyy HH:mm:ss ZZZ").format(date, usPacific));
+  //
+  //    assertEquals("02/27/2006 05:10:10 GMT-08:00", DateTimeFormat.getFormat(
+  //        "MM/dd/yyyy HH:mm:ss ZZZZ").format(date, usPacific));
+  //  }
 
   public void test_yyyyyMMMMM() {
     Date date = new Date(2006 - 1900, 6, 27, 13, 10, 10);
-    assertEquals("02006.J.27 AD 01:10 PM", DateTimeFormat.getFormat(
-        "yyyyy.MMMMM.dd GGG hh:mm aaa").format(date));
+    assertEquals(
+        "02006.J.27 AD 01:10 PM",
+        DateTimeFormat.getFormat("yyyyy.MMMMM.dd GGG hh:mm aaa").format(date));
   }
 
-//
-//  public void testMessageDateTime() {
-//    MyMessages m = GWT.create(MyMessages.class);
-//    Date d = new Date(2010 - 1900, 1, 15, 12, 0, 0);
-//    assertEquals("It is Feb 15, 2010", m.getCustomizedDate(d));
-//  }
+  //
+  //  public void testMessageDateTime() {
+  //    MyMessages m = GWT.create(MyMessages.class);
+  //    Date d = new Date(2010 - 1900, 1, 15, 12, 0, 0);
+  //    assertEquals("It is Feb 15, 2010", m.getCustomizedDate(d));
+  //  }
 
   public void testPatternCaching() {
     DateTimeFormat dtf = DateTimeFormat.getFormat("MMMM d");
@@ -555,19 +546,19 @@ public class DateTimeFormat_en_Test extends DateTimeFormatTestBase {
 
   public void testPre1970Milliseconds() {
     Date date = new Date(-631151998945L); // Jan 1, 1950 00:00:01.055 UTC
-    
+
     long midnight = Date.UTC(1950 - 1900, 0, 1, 0, 0, 1);
     assertEquals(-631151998945L, midnight + 55);
-    
+
     TimeZone utc = TimeZone.createTimeZone(0);
     assertEquals("055", DateTimeFormat.getFormat("SSS").format(date, utc));
     assertEquals("06", DateTimeFormat.getFormat("SS").format(date, utc));
     assertEquals("1", DateTimeFormat.getFormat("S").format(date, utc));
-    
+
     date = new Date(midnight);
     assertEquals("000", DateTimeFormat.getFormat("SSS").format(date, utc));
   }
-  
+
   public void testZeroPadYear() {
     DateTimeFormat fmt = DateTimeFormat.getFormat("dd.MM.yyyy");
     String str = fmt.format(new Date(1 - 1900, 0, 1)); // 1 Jan 0001

--- a/gwt-datetimeformat/src/test/java/org/gwtproject/i18n/client/DateTimeFormat_fil_Test.java
+++ b/gwt-datetimeformat/src/test/java/org/gwtproject/i18n/client/DateTimeFormat_fil_Test.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2009 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -15,15 +15,11 @@
  */
 package org.gwtproject.i18n.client;
 
+import java.util.Date;
 import org.gwtproject.i18n.shared.DateTimeFormatTestBase;
 import org.junit.Before;
 
-import java.util.Date;
-
-/**
- * Tests unique functionality in {@link DateTimeFormat} for the Filipino
- * language.
- */
+/** Tests unique functionality in {@link DateTimeFormat} for the Filipino language. */
 @SuppressWarnings("deprecation")
 public class DateTimeFormat_fil_Test extends DateTimeFormatTestBase {
 

--- a/gwt-datetimeformat/src/test/java/org/gwtproject/i18n/client/DateTimeFormat_pl_Test.java
+++ b/gwt-datetimeformat/src/test/java/org/gwtproject/i18n/client/DateTimeFormat_pl_Test.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2009 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -15,15 +15,10 @@
  */
 package org.gwtproject.i18n.client;
 
-import com.google.gwt.junit.client.GWTTestCase;
+import java.util.Date;
 import org.gwtproject.i18n.shared.DateTimeFormatTestBase;
 
-import java.util.Date;
-
-/**
- * Tests unique functionality in {@link DateTimeFormat} for the Polish
- * language.
- */
+/** Tests unique functionality in {@link DateTimeFormat} for the Polish language. */
 @SuppressWarnings("deprecation")
 public class DateTimeFormat_pl_Test extends DateTimeFormatTestBase {
 

--- a/gwt-datetimeformat/src/test/java/org/gwtproject/i18n/client/DateTimeParse_en_Test.java
+++ b/gwt-datetimeformat/src/test/java/org/gwtproject/i18n/client/DateTimeParse_en_Test.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2008 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -16,19 +16,14 @@
 
 package org.gwtproject.i18n.client;
 
+import java.util.Date;
 import org.gwtproject.i18n.shared.DateTimeFormatTestBase;
 
-import java.util.Date;
-
-/**
- * Tests parsing functionality in {@link DateTimeFormat} for the English
- * language.
- */
+/** Tests parsing functionality in {@link DateTimeFormat} for the English language. */
 @SuppressWarnings("deprecation")
-public class DateTimeParse_en_Test  extends DateTimeFormatTestBase {
+public class DateTimeParse_en_Test extends DateTimeFormatTestBase {
   // TODO: replace the rest of the assertTrue calls to assertEquals
   //    for better error reporting, where possible.
-
 
   @Override
   public void setUp() throws Exception {
@@ -84,8 +79,8 @@ public class DateTimeParse_en_Test  extends DateTimeFormatTestBase {
 
   public void testAmbiguousYear() {
     Date date = new Date();
-    if (date.getMonth() == 0 && date.getDate() == 1 || date.getMonth() == 11
-        && date.getDate() >= 31) {
+    if (date.getMonth() == 0 && date.getDate() == 1
+        || date.getMonth() == 11 && date.getDate() >= 31) {
       // we are using current time to resolve ambiguous year.
       // This test case is not designed to work on new year's eve and new year.
       return;
@@ -111,10 +106,9 @@ public class DateTimeParse_en_Test  extends DateTimeFormatTestBase {
   }
 
   /**
-   * Parse the pattern MMMMyyyy when the day of the current month is passed the
-   * last day of the parsed leap month. For example, parse "February2004" (leap
-   * month) on January 31. The date should be limited to the last day of the
-   * month.
+   * Parse the pattern MMMMyyyy when the day of the current month is passed the last day of the
+   * parsed leap month. For example, parse "February2004" (leap month) on January 31. The date
+   * should be limited to the last day of the month.
    */
   public void testCurrentDayInvalidInParsedLeapMonth() {
     // Parse "February2004" (leap year) on January 31, 2006.
@@ -127,9 +121,9 @@ public class DateTimeParse_en_Test  extends DateTimeFormatTestBase {
   }
 
   /**
-   * Parse the pattern MMMMyyyy when the day of the current month is passed the
-   * last day of the parsed month. For example, parse "February2006" on January
-   * 31. The date should be limited to the last day of the month.
+   * Parse the pattern MMMMyyyy when the day of the current month is passed the last day of the
+   * parsed month. For example, parse "February2006" on January 31. The date should be limited to
+   * the last day of the month.
    */
   public void testCurrentDayInvalidInParsedMonth() {
     // Parse "February2006" on January 31, 2006.
@@ -142,9 +136,9 @@ public class DateTimeParse_en_Test  extends DateTimeFormatTestBase {
   }
 
   /**
-   * Parse the pattern MMMMyyyy when the day of the current month is passed the
-   * last day of the parsed month. For example, parse "February2006" on January
-   * 31. The date should be limited to the last day of the month.
+   * Parse the pattern MMMMyyyy when the day of the current month is passed the last day of the
+   * parsed month. For example, parse "February2006" on January 31. The date should be limited to
+   * the last day of the month.
    */
   public void testCurrentDayInvalidInParsedMonthStrict() {
     // Parse "February2006" on January 31, 2006.
@@ -157,9 +151,8 @@ public class DateTimeParse_en_Test  extends DateTimeFormatTestBase {
   }
 
   /**
-   * Parse the pattern MMMMyyyy when the day of the current month is within the
-   * last day of the parsed month. For example, parse "February2006" on January
-   * 10.
+   * Parse the pattern MMMMyyyy when the day of the current month is within the last day of the
+   * parsed month. For example, parse "February2006" on January 10.
    */
   public void testCurrentDayValidInParsedMonth() {
     // Set the date to January 31, 2006.
@@ -181,9 +174,8 @@ public class DateTimeParse_en_Test  extends DateTimeFormatTestBase {
   }
 
   /**
-   * Issue 4633: Test that an empty integer value throws an
-   * {@link IllegalArgumentException}, but does not throw an
-   * {@link IndexOutOfBoundsException}.
+   * Issue 4633: Test that an empty integer value throws an {@link IllegalArgumentException}, but
+   * does not throw an {@link IndexOutOfBoundsException}.
    */
   public void testEmptyIntegerValue() {
     char[] parts = new char[] {'M', 'd', 'y', 'h', 'H', 'm', 's', 'S', 'k'};
@@ -209,9 +201,7 @@ public class DateTimeParse_en_Test  extends DateTimeFormatTestBase {
     assertEquals(44, date.getMinutes());
   }
 
-  /**
-   * Add as many tests as you like.
-   */
+  /** Add as many tests as you like. */
   public void testFractionalSeconds() {
     Date date = new Date();
 
@@ -731,22 +721,18 @@ public class DateTimeParse_en_Test  extends DateTimeFormatTestBase {
   public void testTimeZone() {
     Date date = new Date();
 
-    assertTrue(parse("MM/dd/yyyy, hh:mm:ss zzz",
-        "07/21/2003, 11:22:33 GMT-0700", 0, date) > 0);
+    assertTrue(parse("MM/dd/yyyy, hh:mm:ss zzz", "07/21/2003, 11:22:33 GMT-0700", 0, date) > 0);
     int gmtNegative07 = date.getHours();
 
-    assertTrue(parse("MM/dd/yyyy, hh:mm:ss zzz",
-        "07/21/2003, 11:22:33 GMT-0600", 0, date) > 0);
+    assertTrue(parse("MM/dd/yyyy, hh:mm:ss zzz", "07/21/2003, 11:22:33 GMT-0600", 0, date) > 0);
     int gmtNegative06 = date.getHours();
     assertTrue((gmtNegative07 + 24 - gmtNegative06) % 24 == 1);
 
-    assertTrue(parse("MM/dd/yyyy, hh:mm:ss zzz",
-        "07/21/2003, 11:22:33 GMT-0800", 0, date) > 0);
+    assertTrue(parse("MM/dd/yyyy, hh:mm:ss zzz", "07/21/2003, 11:22:33 GMT-0800", 0, date) > 0);
     int gmtNegative08 = date.getHours();
     assertTrue((gmtNegative08 + 24 - gmtNegative07) % 24 == 1);
 
-    assertTrue(parse("MM/dd/yyyy, HH:mm:ss zzz",
-        "07/21/2003, 11:22:33 GMT+0800", 0, date) > 0);
+    assertTrue(parse("MM/dd/yyyy, HH:mm:ss zzz", "07/21/2003, 11:22:33 GMT+0800", 0, date) > 0);
     int gmtPositive08 = date.getHours();
     assertTrue((gmtNegative08 + 24 - gmtPositive08) % 24 == 16);
   }

--- a/gwt-datetimeformat/src/test/java/org/gwtproject/i18n/client/DateTimeParse_zh_CN_Test.java
+++ b/gwt-datetimeformat/src/test/java/org/gwtproject/i18n/client/DateTimeParse_zh_CN_Test.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2006 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -16,16 +16,12 @@
 
 package org.gwtproject.i18n.client;
 
+import java.util.Date;
 import org.gwtproject.i18n.client.DateTimeFormat.PredefinedFormat;
 import org.gwtproject.i18n.shared.DateTimeFormatTestBase;
 
-import java.util.Date;
-
-/**
- * Tests formatting functionality in {@link DateTimeFormat} for the Chinese
- * language.
- */
-public class DateTimeParse_zh_CN_Test  extends DateTimeFormatTestBase {
+/** Tests formatting functionality in {@link DateTimeFormat} for the Chinese language. */
+public class DateTimeParse_zh_CN_Test extends DateTimeFormatTestBase {
 
   @Override
   public void setUp() throws Exception {
@@ -45,8 +41,8 @@ public class DateTimeParse_zh_CN_Test  extends DateTimeFormatTestBase {
        * disagree about whether or not daylight savings time is in effect on day
        * 0 of the epoch.
        */
-      long expectedTimeUTC = Date.UTC(date.getYear(), date.getMonth(),
-          date.getDate(), 15 + 7, 26, 28);
+      long expectedTimeUTC =
+          Date.UTC(date.getYear(), date.getMonth(), date.getDate(), 15 + 7, 26, 28);
       Date expectedDate = new Date(expectedTimeUTC);
 
       assertEquals(expectedDate.getHours(), date.getHours());
@@ -56,8 +52,7 @@ public class DateTimeParse_zh_CN_Test  extends DateTimeFormatTestBase {
 
     {
       String date_2006_07_24 = "2006\u5E747\u670824\u65e5\u661f\u671f\u4e00";
-      assertTrue(DateTimeFormat.getFullDateFormat().parse(date_2006_07_24, 0,
-          date) > 0);
+      assertTrue(DateTimeFormat.getFullDateFormat().parse(date_2006_07_24, 0, date) > 0);
 
       // Create the expected date object, adjusting for the local timezone.
       long localTzOffset = new Date().getTimezoneOffset();

--- a/gwt-datetimeformat/src/test/java/org/gwtproject/i18n/shared/DateTimeFormatTestBase.java
+++ b/gwt-datetimeformat/src/test/java/org/gwtproject/i18n/shared/DateTimeFormatTestBase.java
@@ -15,32 +15,28 @@
  */
 package org.gwtproject.i18n.shared;
 
+import java.util.Date;
 import junit.framework.TestCase;
 import org.gwtproject.i18n.shared.DateTimeFormat.PredefinedFormat;
 
-import java.util.Date;
+// import org.gwtproject.i18n.client.Messages;
 
-//import org.gwtproject.i18n.client.Messages;
-
-/**
- * Base class for date/time format tests.
- */
+/** Base class for date/time format tests. */
 public abstract class DateTimeFormatTestBase extends TestCase {
 
-  /**
-   * The timezone used by any tests which use a fixed timezone.
-   */
-  protected static final TimeZone TEST_TIMEZONE = org.gwtproject.i18n.client.TimeZone.createTimeZone(300);
+  /** The timezone used by any tests which use a fixed timezone. */
+  protected static final TimeZone TEST_TIMEZONE =
+      org.gwtproject.i18n.client.TimeZone.createTimeZone(300);
 
   //  /**
-//   * Test date/time formats in messages.
-//   */
-//  public interface MyMessages extends Messages {
-//    @DefaultMessage("It is {0,localdatetime,dMMMy}")
-//    String getCustomizedDate(Date date);
-//  }
+  //   * Test date/time formats in messages.
+  //   */
+  //  public interface MyMessages extends Messages {
+  //    @DefaultMessage("It is {0,localdatetime,dMMMy}")
+  //    String getCustomizedDate(Date date);
+  //  }
 
-  protected void setLocale(String locale){
+  protected void setLocale(String locale) {
     System.setProperty("locale", locale);
   }
 

--- a/gwt-i18n-processor-util/src/main/java/org/gwtproject/ext/BadPropertyValueException.java
+++ b/gwt-i18n-processor-util/src/main/java/org/gwtproject/ext/BadPropertyValueException.java
@@ -15,9 +15,7 @@
  */
 package org.gwtproject.ext;
 
-/**
- * Thrown when a deferred binding property contains an invalid value.
- */
+/** Thrown when a deferred binding property contains an invalid value. */
 public class BadPropertyValueException extends Exception {
 
   private final String badValue;
@@ -32,8 +30,7 @@ public class BadPropertyValueException extends Exception {
   }
 
   public BadPropertyValueException(String propName, String badValue) {
-    super("Property '" + propName + "' cannot be set to unexpected value '"
-      + badValue + "'");
+    super("Property '" + propName + "' cannot be set to unexpected value '" + badValue + "'");
 
     this.propName = propName;
     this.badValue = badValue;
@@ -42,6 +39,7 @@ public class BadPropertyValueException extends Exception {
   String getBadValue() {
     return badValue;
   }
+
   String getPropName() {
     return propName;
   }

--- a/gwt-i18n-processor-util/src/main/java/org/gwtproject/ext/ConfigurationProperties.java
+++ b/gwt-i18n-processor-util/src/main/java/org/gwtproject/ext/ConfigurationProperties.java
@@ -1,52 +1,57 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.gwtproject.ext;
 
-import javax.annotation.processing.Filer;
-import javax.tools.FileObject;
-import javax.tools.StandardLocation;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 
-/**
- * @author Dmitrii Tikhomirov
- * Created by treblereel 11/7/18
- */
+/** @author Dmitrii Tikhomirov Created by treblereel 11/7/18 */
 public final class ConfigurationProperties {
 
+  private final Map<String, ConfigurationProperty> holder = new HashMap<>();
 
-    private final Map<String, ConfigurationProperty> holder = new HashMap<>();
+  public ConfigurationProperties() {
+    setDefaultProperties();
+  }
 
-    public ConfigurationProperties() {
-        setDefaultProperties();
+  private void setDefaultProperties() {
+    lookupAndSet("locale", Arrays.asList("default"), false);
+  }
+
+  private void lookupAndSet(String propertyName, List<String> defaulValues, boolean override) {
+    List<String> list = new ArrayList<>(defaulValues);
+    holder.put(
+        propertyName, lookup(new DefaultConfigurationProperty(propertyName, list), override));
+  }
+
+  private ConfigurationProperty lookup(ConfigurationProperty holder, boolean override) {
+    String values = System.getProperty(holder.getName());
+    if (values != null) {
+      if (override) {
+        holder.getValues().clear();
+      }
+      Arrays.stream(values.split("\\s+")).forEach(e -> holder.getValues().add(e));
     }
+    return holder;
+  }
 
-    private void setDefaultProperties() {
-        lookupAndSet("locale", Arrays.asList("default"), false);
+  public ConfigurationProperty getConfigurationProperty(String key)
+      throws BadPropertyValueException {
+    if (holder.containsKey(key)) {
+      return holder.get(key);
     }
-
-    private void lookupAndSet(String propertyName, List<String> defaulValues, boolean override) {
-        List<String> list = new ArrayList<>(defaulValues);
-        holder.put(propertyName, lookup(
-                new DefaultConfigurationProperty(propertyName, list), override));
-    }
-
-    private ConfigurationProperty lookup(ConfigurationProperty holder, boolean override) {
-        String values = System.getProperty(holder.getName());
-        if (values != null) {
-            if (override) {
-                holder.getValues().clear();
-            }
-            Arrays.stream(values.split("\\s+")).forEach(e -> holder.getValues().add(e));
-        }
-        return holder;
-    }
-
-    public ConfigurationProperty getConfigurationProperty(String key) throws BadPropertyValueException {
-        if (holder.containsKey(key)) {
-            return holder.get(key);
-        }
-        throw new BadPropertyValueException(key);
-    }
+    throw new BadPropertyValueException(key);
+  }
 }

--- a/gwt-i18n-processor-util/src/main/java/org/gwtproject/ext/ConfigurationProperty.java
+++ b/gwt-i18n-processor-util/src/main/java/org/gwtproject/ext/ConfigurationProperty.java
@@ -18,26 +18,24 @@ package org.gwtproject.ext;
 
 import java.util.List;
 
-/**
- * A named configuration (property, values) pair.
- */
+/** A named configuration (property, values) pair. */
 public interface ConfigurationProperty {
 
-    /**
-     * The name of the property.
-     *
-     * @return the property name as a String.
-     */
-    String getName();
+  /**
+   * The name of the property.
+   *
+   * @return the property name as a String.
+   */
+  String getName();
 
-    /**
-     * The values for the permutation currently being considered.
-     *
-     * @return the property values as a List of Strings.
-     */
-    List<String> getValues();
+  /**
+   * The values for the permutation currently being considered.
+   *
+   * @return the property values as a List of Strings.
+   */
+  List<String> getValues();
 
-    String asSingleValue() throws UnableToCompleteException;
+  String asSingleValue() throws UnableToCompleteException;
 
-    Boolean asSingleBooleanValue() throws UnableToCompleteException;
+  Boolean asSingleBooleanValue() throws UnableToCompleteException;
 }

--- a/gwt-i18n-processor-util/src/main/java/org/gwtproject/ext/DefaultConfigurationProperty.java
+++ b/gwt-i18n-processor-util/src/main/java/org/gwtproject/ext/DefaultConfigurationProperty.java
@@ -18,79 +18,78 @@ package org.gwtproject.ext;
 import java.util.List;
 
 /**
- * Default immutable implementation of ConfigurationProperty that receives its
- * values in its constructor.
+ * Default immutable implementation of ConfigurationProperty that receives its values in its
+ * constructor.
  */
 public class DefaultConfigurationProperty implements ConfigurationProperty {
 
-    private final String name;
-    private final List<String> values;
+  private final String name;
+  private final List<String> values;
 
-    /**
-     * Construct a configuration property.
-     *
-     * @param name   the name of this property, must not be null
-     * @param values the list of possible values, must not be null and
-     *               will be returned to callers, so a copy should be passed into this
-     *               ctor if the caller will use this set later
-     */
-    public DefaultConfigurationProperty(String name, List<String> values) {
-        assert name != null;
-        assert values != null;
-        this.name = name;
-        this.values = values;
-    }
+  /**
+   * Construct a configuration property.
+   *
+   * @param name the name of this property, must not be null
+   * @param values the list of possible values, must not be null and will be returned to callers, so
+   *     a copy should be passed into this ctor if the caller will use this set later
+   */
+  public DefaultConfigurationProperty(String name, List<String> values) {
+    assert name != null;
+    assert values != null;
+    this.name = name;
+    this.values = values;
+  }
 
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        DefaultConfigurationProperty other = (DefaultConfigurationProperty) obj;
-        return name.equals(other.name)
-                && values.equals(other.values);
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
     }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    DefaultConfigurationProperty other = (DefaultConfigurationProperty) obj;
+    return name.equals(other.name) && values.equals(other.values);
+  }
 
-    @Override
-    public List<String> getValues() {
-        return values;
-    }
+  @Override
+  public List<String> getValues() {
+    return values;
+  }
 
-    @Override
-    public String asSingleValue() throws UnableToCompleteException {
-        if (values.size() > 1) {
-            throw new UnableToCompleteException("The configuration property " + getName() + " cannot be a multi-valued property");
-        }
-        return values.get(0);
+  @Override
+  public String asSingleValue() throws UnableToCompleteException {
+    if (values.size() > 1) {
+      throw new UnableToCompleteException(
+          "The configuration property " + getName() + " cannot be a multi-valued property");
     }
+    return values.get(0);
+  }
 
-    @Override
-    public Boolean asSingleBooleanValue() throws UnableToCompleteException {
-        return Boolean.valueOf(asSingleValue());
-    }
+  @Override
+  public Boolean asSingleBooleanValue() throws UnableToCompleteException {
+    return Boolean.valueOf(asSingleValue());
+  }
 
-    @Override
-    public String getName() {
-        return name;
-    }
+  @Override
+  public String getName() {
+    return name;
+  }
 
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + name.hashCode();
-        result = prime * result + values.hashCode();
-        return result;
-    }
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + name.hashCode();
+    result = prime * result + values.hashCode();
+    return result;
+  }
 
-    @Override
-    public String toString() {
-        return "ConfigProp " + name + ": " + values.toString();
-    }
+  @Override
+  public String toString() {
+    return "ConfigProp " + name + ": " + values.toString();
+  }
 }

--- a/gwt-i18n-processor-util/src/main/java/org/gwtproject/ext/PropertyOracle.java
+++ b/gwt-i18n-processor-util/src/main/java/org/gwtproject/ext/PropertyOracle.java
@@ -17,25 +17,21 @@ package org.gwtproject.ext;
 
 import javax.annotation.processing.Messager;
 
-/**
- * Provides deferred binding property values.
- */
+/** Provides deferred binding property values. */
 public interface PropertyOracle {
 
-    /**
-     * Attempts to get a named configuration property. Throws
-     * <code>UnableToCompleteException</code> if the property is undefined. The
-     * result of invoking this method with the same <code>propertyName</code> must
-     * be stable.
-     *
-     * @param propertyName
-     * @return the configuration property instance (never null)
-     * @throws UnableToCompleteException if the property is unknown or not a
-     *                                   configuration property
-     */
-    ConfigurationProperty getConfigurationProperty(String propertyName)
-            throws UnableToCompleteException;
+  /**
+   * Attempts to get a named configuration property. Throws <code>UnableToCompleteException</code>
+   * if the property is undefined. The result of invoking this method with the same <code>
+   * propertyName</code> must be stable.
+   *
+   * @param propertyName
+   * @return the configuration property instance (never null)
+   * @throws UnableToCompleteException if the property is unknown or not a configuration property
+   */
+  ConfigurationProperty getConfigurationProperty(String propertyName)
+      throws UnableToCompleteException;
 
-    SelectionProperty getSelectionProperty(Messager logger, String propertyName)
-            throws UnableToCompleteException;
+  SelectionProperty getSelectionProperty(Messager logger, String propertyName)
+      throws UnableToCompleteException;
 }

--- a/gwt-i18n-processor-util/src/main/java/org/gwtproject/ext/PropertyOracleImpl.java
+++ b/gwt-i18n-processor-util/src/main/java/org/gwtproject/ext/PropertyOracleImpl.java
@@ -1,43 +1,59 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.gwtproject.ext;
 
 import javax.annotation.processing.Messager;
 import javax.tools.Diagnostic;
 
-/**
- * @author Dmitrii Tikhomirov
- * Created by treblereel 12/5/18
- */
+/** @author Dmitrii Tikhomirov Created by treblereel 12/5/18 */
 public class PropertyOracleImpl implements PropertyOracle {
-    public final ConfigurationProperties configurationProperties;
+  public final ConfigurationProperties configurationProperties;
 
-    public PropertyOracleImpl() {
-        configurationProperties = new ConfigurationProperties();
-    }
+  public PropertyOracleImpl() {
+    configurationProperties = new ConfigurationProperties();
+  }
 
-    @Override
-    public ConfigurationProperty getConfigurationProperty(String propertyName) throws UnableToCompleteException {
-        ConfigurationProperty configurationProperty;
-        try {
-            configurationProperty = configurationProperties.getConfigurationProperty(propertyName);
-        } catch (BadPropertyValueException e) {
-            throw new UnableToCompleteException();
-        }
-        return configurationProperty;
+  @Override
+  public ConfigurationProperty getConfigurationProperty(String propertyName)
+      throws UnableToCompleteException {
+    ConfigurationProperty configurationProperty;
+    try {
+      configurationProperty = configurationProperties.getConfigurationProperty(propertyName);
+    } catch (BadPropertyValueException e) {
+      throw new UnableToCompleteException();
     }
+    return configurationProperty;
+  }
 
-    @Override
-    public SelectionProperty getSelectionProperty(Messager logger, String propertyName) throws UnableToCompleteException {
-        String value = System.getProperty(propertyName);
-        if (value != null) {
-            return new StandardSelectionProperty(propertyName, value);
-        } else {
-            try {
-                ConfigurationProperty configurationProperty = configurationProperties.getConfigurationProperty(propertyName);
-                return new StandardSelectionProperty(propertyName, configurationProperty.asSingleValue());
-            } catch (BadPropertyValueException e) {
-                logger.printMessage(Diagnostic.Kind.ERROR, "Unable to get selection property : " + propertyName);
-                throw new UnableToCompleteException();
-            }
-        }
+  @Override
+  public SelectionProperty getSelectionProperty(Messager logger, String propertyName)
+      throws UnableToCompleteException {
+    String value = System.getProperty(propertyName);
+    if (value != null) {
+      return new StandardSelectionProperty(propertyName, value);
+    } else {
+      try {
+        ConfigurationProperty configurationProperty =
+            configurationProperties.getConfigurationProperty(propertyName);
+        return new StandardSelectionProperty(propertyName, configurationProperty.asSingleValue());
+      } catch (BadPropertyValueException e) {
+        logger.printMessage(
+            Diagnostic.Kind.ERROR, "Unable to get selection property : " + propertyName);
+        throw new UnableToCompleteException();
+      }
     }
+  }
 }

--- a/gwt-i18n-processor-util/src/main/java/org/gwtproject/ext/SelectionProperty.java
+++ b/gwt-i18n-processor-util/src/main/java/org/gwtproject/ext/SelectionProperty.java
@@ -1,31 +1,43 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.gwtproject.ext;
 
 import java.util.SortedSet;
 
-/**
- * A named deferred binding (property, value) pair for use in generators.
- *
- */
+/** A named deferred binding (property, value) pair for use in generators. */
 public interface SelectionProperty {
 
-    /**
-     * The name of the property.
-     *
-     * @return the property name as a String.
-     * */
-    String getName();
+  /**
+   * The name of the property.
+   *
+   * @return the property name as a String.
+   */
+  String getName();
 
-    /**
-     * The value for the permutation currently being considered.
-     *
-     * @return the property value as a String.
-     */
-    String getCurrentValue();
+  /**
+   * The value for the permutation currently being considered.
+   *
+   * @return the property value as a String.
+   */
+  String getCurrentValue();
 
-    /**
-     * Returns the possible values for the property in sorted order.
-     *
-     * @return a SortedSet of Strings containing the possible property values.
-     */
-    SortedSet<String> getPossibleValues();
+  /**
+   * Returns the possible values for the property in sorted order.
+   *
+   * @return a SortedSet of Strings containing the possible property values.
+   */
+  SortedSet<String> getPossibleValues();
 }

--- a/gwt-i18n-processor-util/src/main/java/org/gwtproject/ext/StandardSelectionProperty.java
+++ b/gwt-i18n-processor-util/src/main/java/org/gwtproject/ext/StandardSelectionProperty.java
@@ -1,37 +1,47 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.gwtproject.ext;
 
+import java.util.SortedSet;
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
-import java.util.SortedSet;
-
-/**
- * @author Dmitrii Tikhomirov
- * Created by treblereel 12/5/18
- */
+/** @author Dmitrii Tikhomirov Created by treblereel 12/5/18 */
 public class StandardSelectionProperty implements SelectionProperty {
 
-    private final String name;
-    private SortedSet<String> values;
-    private final String activeValue;
+  private final String name;
+  private SortedSet<String> values;
+  private final String activeValue;
 
+  public StandardSelectionProperty(String name, String activeValue) {
+    this.activeValue = activeValue;
+    this.name = name;
+  }
 
-    public StandardSelectionProperty(String name, String activeValue){
-        this.activeValue = activeValue;
-        this.name = name;
-    }
+  @Override
+  public String getName() {
+    return name;
+  }
 
-    @Override
-    public String getName() {
-        return name;
-    }
+  @Override
+  public String getCurrentValue() {
+    return activeValue;
+  }
 
-    @Override
-    public String getCurrentValue() {
-        return activeValue;
-    }
-
-    @Override
-    public SortedSet<String> getPossibleValues() {
-        throw new NotImplementedException();
-    }
+  @Override
+  public SortedSet<String> getPossibleValues() {
+    throw new NotImplementedException();
+  }
 }

--- a/gwt-i18n-processor-util/src/main/java/org/gwtproject/ext/UnableToCompleteException.java
+++ b/gwt-i18n-processor-util/src/main/java/org/gwtproject/ext/UnableToCompleteException.java
@@ -16,29 +16,28 @@
 package org.gwtproject.ext;
 
 /**
- * Used to indicate that some part of a multi-step process failed. Typically,
- * operation can continue after this exception is caught.
- * <p>
- * Before throwing an object of this type, the thrower
+ * Used to indicate that some part of a multi-step process failed. Typically, operation can continue
+ * after this exception is caught.
+ *
+ * <p>Before throwing an object of this type, the thrower
+ *
  * <ul>
- * <li>must log a detailed user-facing message describing the failure,</li>
- * <li>must report any caught exception using the logger that contributed to
- * the failure, and </li>
- * <li>must not include the cause of the failure in the thrown exception
- * because (1) it will already have been associated with the detailed log entry
- * above and (2) doing so would create a misunderstanding of how to find the
- * causes of low-level errors in that sometimes there is an underlying an
- * exception, sometimes not, but there can <em>always</em> be a preceding log
- * entry. </li>
+ *   <li>must log a detailed user-facing message describing the failure,
+ *   <li>must report any caught exception using the logger that contributed to the failure, and
+ *   <li>must not include the cause of the failure in the thrown exception because (1) it will
+ *       already have been associated with the detailed log entry above and (2) doing so would
+ *       create a misunderstanding of how to find the causes of low-level errors in that sometimes
+ *       there is an underlying an exception, sometimes not, but there can <em>always</em> be a
+ *       preceding log entry.
  * </ul>
- * <p>
- * After catching an object of this type, the catcher
+ *
+ * <p>After catching an object of this type, the catcher
+ *
  * <ul>
- * <li>can be assured that the thrower has already logged a message about the
- * lower-level problem</li>
- * <li>can optionally itself log a higher-level description of the process that
- * was interrupted and the implications of the failure, and if so,</li>
- * <li>should report this caught exception via the logger as well.</li>
+ *   <li>can be assured that the thrower has already logged a message about the lower-level problem
+ *   <li>can optionally itself log a higher-level description of the process that was interrupted
+ *       and the implications of the failure, and if so,
+ *   <li>should report this caught exception via the logger as well.
  * </ul>
  *
  * <pre>
@@ -72,18 +71,17 @@ package org.gwtproject.ext;
  * </pre>
  */
 public class UnableToCompleteException extends Exception {
-    public UnableToCompleteException(String msg, Exception e) {
-        super(msg, e);
-    }
+  public UnableToCompleteException(String msg, Exception e) {
+    super(msg, e);
+  }
 
-    public UnableToCompleteException(Exception e) {
-        super(e);
-    }
+  public UnableToCompleteException(Exception e) {
+    super(e);
+  }
 
-    public UnableToCompleteException(String e) {
-        super(e);
-    }
+  public UnableToCompleteException(String e) {
+    super(e);
+  }
 
-    public UnableToCompleteException() {
-    }
+  public UnableToCompleteException() {}
 }

--- a/gwt-i18n-processor-util/src/main/java/org/gwtproject/i18n/processor/AbstractProcessingStep.java
+++ b/gwt-i18n-processor-util/src/main/java/org/gwtproject/i18n/processor/AbstractProcessingStep.java
@@ -16,15 +16,14 @@
 package org.gwtproject.i18n.processor;
 
 import com.google.auto.common.BasicAnnotationProcessor.ProcessingStep;
-
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 
 public abstract class AbstractProcessingStep implements ProcessingStep {
 
@@ -42,15 +41,11 @@ public abstract class AbstractProcessingStep implements ProcessingStep {
     this.processingEnv = processingEnv;
   }
 
-  /**
-   *
-   * @param e exception to be printed
-   */
+  /** @param e exception to be printed */
   public void printStackTrace(Exception e) {
     StringWriter out = new StringWriter();
     e.printStackTrace(new PrintWriter(out));
-    messager.printMessage(Diagnostic.Kind.ERROR, "error while creating source file " + out.getBuffer().toString());
+    messager.printMessage(
+        Diagnostic.Kind.ERROR, "error while creating source file " + out.getBuffer().toString());
   }
-
-
 }

--- a/gwt-i18n-processor-util/src/main/java/org/gwtproject/i18n/processor/DefaultLanguageScripts.java
+++ b/gwt-i18n-processor-util/src/main/java/org/gwtproject/i18n/processor/DefaultLanguageScripts.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2009 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -18,14 +18,10 @@ package org.gwtproject.i18n.processor;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Encodes the mapping of languages to their default script.
- */
+/** Encodes the mapping of languages to their default script. */
 public class DefaultLanguageScripts {
 
-  /**
-   * Maps languages to their default script.
-   */
+  /** Maps languages to their default script. */
   private static Map<String, String> defaultScripts;
 
   static {
@@ -201,7 +197,7 @@ public class DefaultLanguageScripts {
 
   /**
    * Returns the default script for a language, or null if none.
-   * 
+   *
    * @param language language code to get default script for (in lowercase)
    * @return default script for language, or null if none
    */
@@ -210,12 +206,10 @@ public class DefaultLanguageScripts {
   }
 
   /**
-   * Returns the default script for a language/region combination, or null if
-   * none.
-   * 
+   * Returns the default script for a language/region combination, or null if none.
+   *
    * @param language language code to get default script for (in lowercase)
-   * @param region region code to get default script for (in uppercase); may be
-   *     null
+   * @param region region code to get default script for (in uppercase); may be null
    * @return default script for language/region, or null if none
    */
   public static String getDefaultScript(String language, String region) {

--- a/gwt-i18n-processor-util/src/main/java/org/gwtproject/i18n/processor/ExceptionUtil.java
+++ b/gwt-i18n-processor-util/src/main/java/org/gwtproject/i18n/processor/ExceptionUtil.java
@@ -1,21 +1,35 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.gwtproject.i18n.processor;
 
-import javax.annotation.processing.Messager;
-import javax.tools.Diagnostic;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import javax.annotation.processing.Messager;
+import javax.tools.Diagnostic;
 
 public class ExceptionUtil {
 
-    /**
-     *
-     * @param messager the messager to print the exception stack trace
-     * @param e exception to be printed
-     */
-    public static void messageStackTrace(Messager messager, Exception e) {
-        StringWriter out = new StringWriter();
-        e.printStackTrace(new PrintWriter(out));
-        messager.printMessage(Diagnostic.Kind.ERROR, "error while creating source file " + out.getBuffer().toString());
-    }
-
+  /**
+   * @param messager the messager to print the exception stack trace
+   * @param e exception to be printed
+   */
+  public static void messageStackTrace(Messager messager, Exception e) {
+    StringWriter out = new StringWriter();
+    e.printStackTrace(new PrintWriter(out));
+    messager.printMessage(
+        Diagnostic.Kind.ERROR, "error while creating source file " + out.getBuffer().toString());
+  }
 }

--- a/gwt-i18n-processor-util/src/main/java/org/gwtproject/i18n/processor/GwtLocaleFactoryImpl.java
+++ b/gwt-i18n-processor-util/src/main/java/org/gwtproject/i18n/processor/GwtLocaleFactoryImpl.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2009 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -15,17 +15,14 @@
  */
 package org.gwtproject.i18n.processor;
 
-import org.gwtproject.i18n.shared.GwtLocale;
-import org.gwtproject.i18n.shared.GwtLocaleFactory;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import org.gwtproject.i18n.shared.GwtLocale;
+import org.gwtproject.i18n.shared.GwtLocaleFactory;
 
-/**
- * Creates server-side GwtLocale instances.  Thread-safe.
- */
+/** Creates server-side GwtLocale instances. Thread-safe. */
 public class GwtLocaleFactoryImpl implements GwtLocaleFactory {
 
   private static boolean isAlpha(String str, int min, int max) {
@@ -38,17 +35,15 @@ public class GwtLocaleFactoryImpl implements GwtLocaleFactory {
 
   /**
    * Check if the supplied string matches length and composition requirements.
-   * 
+   *
    * @param str string to check
    * @param min minimum length
    * @param max maximum length
-   * @param lettersNotDigits true if all characters should be letters, false if
-   *     all characters should be digits
-   * @return true if the string is of a proper length and contains only the
-   *     specified characters 
+   * @param lettersNotDigits true if all characters should be letters, false if all characters
+   *     should be digits
+   * @return true if the string is of a proper length and contains only the specified characters
    */
-  private static boolean matches(String str, int min, int max,
-      boolean lettersNotDigits) {
+  private static boolean matches(String str, int min, int max, boolean lettersNotDigits) {
     int len = str.length();
     if (len < min || len > max) {
       return false;
@@ -66,32 +61,31 @@ public class GwtLocaleFactoryImpl implements GwtLocaleFactory {
     if (str.length() < 2) {
       return str.toUpperCase(Locale.ROOT);
     }
-    return String.valueOf(Character.toTitleCase(str.charAt(0))) +
-        str.substring(1).toLowerCase(Locale.ROOT);
+    return String.valueOf(Character.toTitleCase(str.charAt(0)))
+        + str.substring(1).toLowerCase(Locale.ROOT);
   }
 
   private final Object instanceCacheLock = new Object[0];
-  
+
   // Locales are stored pointing at themselves. A new instance is created,
   // which is pretty cheap, then looked up here. If it exists, the old
   // one is used instead to preserved cached data structures.
-  private Map<GwtLocaleImpl, GwtLocaleImpl> instanceCache
-      = new HashMap<GwtLocaleImpl, GwtLocaleImpl>();
+  private Map<GwtLocaleImpl, GwtLocaleImpl> instanceCache =
+      new HashMap<GwtLocaleImpl, GwtLocaleImpl>();
 
   /**
    * Clear an embedded cache of instances when they are no longer needed.
-   * <p>
-   * Note that GwtLocale instances constructed after this is called will not
-   * maintain identity with instances constructed before this call.
+   *
+   * <p>Note that GwtLocale instances constructed after this is called will not maintain identity
+   * with instances constructed before this call.
    */
   public void clear() {
     synchronized (instanceCacheLock) {
-      instanceCache.clear();     
+      instanceCache.clear();
     }
   }
 
-  public GwtLocale fromComponents(String language, String script,
-                                  String region, String variant) {
+  public GwtLocale fromComponents(String language, String script, String region, String variant) {
     if (language != null && language.length() == 0) {
       language = null;
     }
@@ -116,8 +110,7 @@ public class GwtLocaleFactoryImpl implements GwtLocaleFactory {
     if (variant != null) {
       variant = variant.toUpperCase(Locale.ROOT);
     }
-    GwtLocaleImpl locale = new GwtLocaleImpl(this, language, region, script,
-        variant);
+    GwtLocaleImpl locale = new GwtLocaleImpl(this, language, region, script, variant);
     synchronized (instanceCacheLock) {
       if (instanceCache.containsKey(locale)) {
         return instanceCache.get(locale);
@@ -128,8 +121,8 @@ public class GwtLocaleFactoryImpl implements GwtLocaleFactory {
   }
 
   /**
-   * @throws IllegalArgumentException if the supplied locale does not match
-   *     BCP47 structural requirements.
+   * @throws IllegalArgumentException if the supplied locale does not match BCP47 structural
+   *     requirements.
    */
   public GwtLocale fromString(String localeName) {
     String language = null;
@@ -147,7 +140,7 @@ public class GwtLocaleFactoryImpl implements GwtLocaleFactory {
           localeParts.add(parts[i]);
         }
       }
-      
+
       // figure out the role of each part
       int partIdx = 1;
       int numParts = localeParts.size();
@@ -161,8 +154,7 @@ public class GwtLocaleFactoryImpl implements GwtLocaleFactory {
         // See if we have extended language tags
         if ((len == 2 || len == 3) && partIdx < numParts) {
           String part = localeParts.get(partIdx);
-          while (partIdx < numParts && partIdx < 4
-              && isAlpha(part, 3, 3)) {
+          while (partIdx < numParts && partIdx < 4 && isAlpha(part, 3, 3)) {
             language += '-' + part;
             if (++partIdx >= numParts) {
               break;
@@ -171,8 +163,7 @@ public class GwtLocaleFactoryImpl implements GwtLocaleFactory {
           }
         }
       }
-      if (numParts > partIdx
-          && isAlpha(localeParts.get(partIdx), 4, 4)) {
+      if (numParts > partIdx && isAlpha(localeParts.get(partIdx), 4, 4)) {
         // Scripts are exactly 4 letters
         script = localeParts.get(partIdx++);
       }
@@ -188,15 +179,13 @@ public class GwtLocaleFactoryImpl implements GwtLocaleFactory {
         // Variants are 5-8 alphanum, or 4 alphanum if first is digit
         String part = localeParts.get(partIdx);
         int len = part.length();
-        if ((len >= 5 && len <= 8) || (len == 4
-            && Character.isDigit(part.charAt(0)))) {
+        if ((len >= 5 && len <= 8) || (len == 4 && Character.isDigit(part.charAt(0)))) {
           variant = part;
           ++partIdx;
         }
       }
       if (partIdx < numParts) {
-        throw new IllegalArgumentException("Unrecognized locale format: "
-            + localeName);
+        throw new IllegalArgumentException("Unrecognized locale format: " + localeName);
       }
     }
     return fromComponents(language, script, region, variant);

--- a/gwt-i18n-processor-util/src/main/java/org/gwtproject/i18n/processor/GwtLocaleImpl.java
+++ b/gwt-i18n-processor-util/src/main/java/org/gwtproject/i18n/processor/GwtLocaleImpl.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2009 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -15,15 +15,14 @@
  */
 package org.gwtproject.i18n.processor;
 
+import java.util.*;
 import org.gwtproject.i18n.shared.GwtLocale;
 import org.gwtproject.i18n.shared.GwtLocaleFactory;
 
-import java.util.*;
-
 /**
  * Class representing GWT locales and conversion to/from other formats.
- * 
- * These locales correspond to BCP47.
+ *
+ * <p>These locales correspond to BCP47.
  */
 public class GwtLocaleImpl implements GwtLocale {
   // TODO(jat): implement a version of this suitable for client-side use,
@@ -32,67 +31,74 @@ public class GwtLocaleImpl implements GwtLocale {
   // the property provider to handle inheritance there.
 
   /**
-   * Maps deprecated language codes to the canonical code.  Strings are always
-   * in pairs, with the first being the canonical code and the second being
-   * a deprecated code which maps to it.
-   * <p>
-   * Source: http://www.loc.gov/standards/iso639-2/php/code_changes.php
-   * <p> 
-   * TODO: consider building maps if this list grows much.
+   * Maps deprecated language codes to the canonical code. Strings are always in pairs, with the
+   * first being the canonical code and the second being a deprecated code which maps to it.
+   *
+   * <p>Source: http://www.loc.gov/standards/iso639-2/php/code_changes.php
+   *
+   * <p>TODO: consider building maps if this list grows much.
    */
-  private static final String[] deprecatedLanguages = new String[] {
-    "he", "iw",   // Hebrew
-    "id", "in",   // Indonesian 
-    "jv", "jw",   // Javanese, typo in original publication 
-    "ro", "mo",   // Moldovian
-    "yi", "ji",   // Yiddish
-  };
+  private static final String[] deprecatedLanguages =
+      new String[] {
+        "he", "iw", // Hebrew
+        "id", "in", // Indonesian
+        "jv", "jw", // Javanese, typo in original publication
+        "ro", "mo", // Moldovian
+        "yi", "ji", // Yiddish
+      };
 
   /**
-   * Maps deprecated region codes to the canonical code.  Strings are always
-   * in pairs, with the first being the canonical code and the second being
-   * a deprecated code which maps to it.
-   * 
-   * Note that any mappings which split an old code into multiple new codes
-   * cannot be done automatically (such as cs -> rs/me) -- perhaps we could
-   * have a way of flagging region codes which are no longer valid and allow
-   * an appropriate warning message.
-   * <p>
-   * Source: http://en.wikipedia.org/wiki/ISO_3166-1
-   * <p>
-   * TODO: consider building maps if this list grows much.
+   * Maps deprecated region codes to the canonical code. Strings are always in pairs, with the first
+   * being the canonical code and the second being a deprecated code which maps to it.
+   *
+   * <p>Note that any mappings which split an old code into multiple new codes cannot be done
+   * automatically (such as cs -> rs/me) -- perhaps we could have a way of flagging region codes
+   * which are no longer valid and allow an appropriate warning message.
+   *
+   * <p>Source: http://en.wikipedia.org/wiki/ISO_3166-1
+   *
+   * <p>TODO: consider building maps if this list grows much.
    */
-  private static final String[] deprecatedRegions = new String[] {
-    // East Timor - http://www.iso.org/iso/newsletter_v-5_east_timor.pdf
-    "TL", "TP",
-  };
+  private static final String[] deprecatedRegions =
+      new String[] {
+        // East Timor - http://www.iso.org/iso/newsletter_v-5_east_timor.pdf
+        "TL", "TP",
+      };
 
   /**
    * Add in the missing locale of a deprecated pair.
-   * 
+   *
    * @param factory GwtLocaleFactory to create new instances with
    * @param locale locale to add deprecated pair for
    * @param aliases where to store the alias if present
    */
-  private static void addDeprecatedPairs(GwtLocaleFactory factory,
-                                         GwtLocale locale, List<GwtLocale> aliases) {
+  private static void addDeprecatedPairs(
+      GwtLocaleFactory factory, GwtLocale locale, List<GwtLocale> aliases) {
     int n = deprecatedLanguages.length;
     for (int i = 0; i < n; i += 2) {
       if (deprecatedLanguages[i].equals(locale.getLanguage())) {
-        aliases.add(factory.fromComponents(deprecatedLanguages[i + 1],
-            locale.getScript(), locale.getRegion(), locale.getVariant()));
+        aliases.add(
+            factory.fromComponents(
+                deprecatedLanguages[i + 1],
+                locale.getScript(),
+                locale.getRegion(),
+                locale.getVariant()));
         break;
       }
       if (deprecatedLanguages[i + 1].equals(locale.getLanguage())) {
-        aliases.add(factory.fromComponents(deprecatedLanguages[i],
-            locale.getScript(), locale.getRegion(), locale.getVariant()));
+        aliases.add(
+            factory.fromComponents(
+                deprecatedLanguages[i],
+                locale.getScript(),
+                locale.getRegion(),
+                locale.getVariant()));
         break;
       }
     }
   }
 
-  private static void addImmediateParentRegions(GwtLocaleFactory factory,
-      GwtLocale locale, Collection<GwtLocale> work) {
+  private static void addImmediateParentRegions(
+      GwtLocaleFactory factory, GwtLocale locale, Collection<GwtLocale> work) {
     String language = locale.getLanguage();
     String script = locale.getScript();
     String region = locale.getRegion();
@@ -123,7 +129,7 @@ public class GwtLocaleImpl implements GwtLocale {
 
   /**
    * Add inherited regions for a given locale.
-   * 
+   *
    * @param factory
    * @param inherits
    * @param language
@@ -131,8 +137,12 @@ public class GwtLocaleImpl implements GwtLocale {
    * @param region
    * @param variant
    */
-  private static void addParentRegionLocales(GwtLocaleFactory factory,
-      List<GwtLocale> inherits, String language, String script, String region,
+  private static void addParentRegionLocales(
+      GwtLocaleFactory factory,
+      List<GwtLocale> inherits,
+      String language,
+      String script,
+      String region,
       String variant) {
     for (String parent : RegionInheritance.getAllAncestors(region)) {
       inherits.add(factory.fromComponents(language, script, parent, variant));
@@ -142,27 +152,27 @@ public class GwtLocaleImpl implements GwtLocale {
   /**
    * Add special aliases for a given locale.
    *
-   * This includes things like choosing the default region for Chinese based on
-   * the script, handling Norwegian language changes, and treating pt_BR as the
-   * default pt type.
+   * <p>This includes things like choosing the default region for Chinese based on the script,
+   * handling Norwegian language changes, and treating pt_BR as the default pt type.
    *
    * @param factory GwtLocaleFactory to create new instances with
    * @param locale locale to add deprecated pair for
    * @param aliases where to store the alias if present
    */
-  private static void addSpecialAliases(GwtLocaleFactory factory,
-      GwtLocale locale, String initialScript, List<GwtLocale> aliases) {
+  private static void addSpecialAliases(
+      GwtLocaleFactory factory, GwtLocale locale, String initialScript, List<GwtLocale> aliases) {
     String language = locale.getLanguage();
     String script = locale.getScript();
     String region = locale.getRegion();
     String variant = locale.getVariant();
-    if ("zh".equals(language) && region == null
+    if ("zh".equals(language)
+        && region == null
         && (initialScript == null || initialScript.equals(script))) {
       // Add aliases for main users of particular scripts, but only if the
       // script matches what was initially supplied.  This is to avoid cases
       // like zh_TW => zh => zh_CN, while still allowing zh => zh_CN.
-      aliases.add(factory.fromComponents("zh", script,
-          "Hant".equals(script) ? "TW" : "CN", variant));
+      aliases.add(
+          factory.fromComponents("zh", script, "Hant".equals(script) ? "TW" : "CN", variant));
     } else if ("no".equals(language)) {
       if (variant == null || "BOKMAL".equals(variant)) {
         aliases.add(factory.fromComponents("nb", script, region, null));
@@ -192,12 +202,10 @@ public class GwtLocaleImpl implements GwtLocale {
   }
 
   /**
-   * Compare strings, accounting for nulls (which are treated as before any
-   * other value).
-   * 
+   * Compare strings, accounting for nulls (which are treated as before any other value).
+   *
    * @param a first string
    * @param b second string
-   * 
    * @return positive if a>b, negative if a<b, 0 if equal
    */
   private static int stringCompare(String a, String b) {
@@ -221,18 +229,16 @@ public class GwtLocaleImpl implements GwtLocale {
   private final String variant;
 
   private final Object cacheLock = new Object[0];
-  
+
   // protected by cacheLock
   private List<GwtLocale> cachedSearchList;
 
   // protected by cacheLock
   private List<GwtLocale> cachedAliases;
 
-  /**
-   * Must only be called from a factory to preserve instance caching.
-   */
-  GwtLocaleImpl(GwtLocaleFactory factory, String language, String region,
-                String script, String variant) {
+  /** Must only be called from a factory to preserve instance caching. */
+  GwtLocaleImpl(
+      GwtLocaleFactory factory, String language, String region, String script, String variant) {
     this.factory = factory;
     this.language = language;
     this.region = region;
@@ -280,15 +286,12 @@ public class GwtLocaleImpl implements GwtLocale {
         ArrayList<GwtLocale> nextGroup = new ArrayList<GwtLocale>();
         nextGroup.add(this);
         // Account for default script
-        String defaultScript = DefaultLanguageScripts.getDefaultScript(language,
-            region);
+        String defaultScript = DefaultLanguageScripts.getDefaultScript(language, region);
         if (defaultScript != null) {
           if (script == null) {
-            nextGroup.add(factory.fromComponents(language, defaultScript,
-                region, variant));
+            nextGroup.add(factory.fromComponents(language, defaultScript, region, variant));
           } else if (script.equals(defaultScript)) {
-            nextGroup.add(factory.fromComponents(language, null, region,
-                variant));
+            nextGroup.add(factory.fromComponents(language, null, region, variant));
           }
         }
         String initialScript = script == null ? defaultScript : script;
@@ -309,7 +312,7 @@ public class GwtLocaleImpl implements GwtLocale {
         }
         cachedAliases = Collections.unmodifiableList(cachedAliases);
       }
-      return cachedAliases;    
+      return cachedAliases;
     }
   }
 
@@ -334,12 +337,13 @@ public class GwtLocaleImpl implements GwtLocale {
   }
 
   /**
-   * Returns this locale in canonical form.  Changes for canonical form are:
+   * Returns this locale in canonical form. Changes for canonical form are:
+   *
    * <ul>
-   *  <li>Deprecated language/region tags are replaced with official versions
+   *   <li>Deprecated language/region tags are replaced with official versions
    * </ul>
-   * 
-   * @return GwtLocale instance 
+   *
+   * @return GwtLocale instance
    */
   public GwtLocale getCanonicalForm() {
     String canonLanguage = language;
@@ -395,12 +399,12 @@ public class GwtLocaleImpl implements GwtLocale {
       }
     }
     // Remove any default script for the language
-    if (canonScript != null && canonScript.equals(
-        DefaultLanguageScripts.getDefaultScript(canonLanguage, canonRegion))) {
+    if (canonScript != null
+        && canonScript.equals(
+            DefaultLanguageScripts.getDefaultScript(canonLanguage, canonRegion))) {
       canonScript = null;
     }
-    return factory.fromComponents(canonLanguage, canonScript, canonRegion,
-        canonVariant);
+    return factory.fromComponents(canonLanguage, canonScript, canonRegion, canonVariant);
   }
 
   public List<GwtLocale> getCompleteSearchList() {
@@ -415,16 +419,14 @@ public class GwtLocaleImpl implements GwtLocale {
         Set<GwtLocale> seen = new HashSet<GwtLocale>();
         String initialScript = script;
         if (initialScript == null) {
-          initialScript = DefaultLanguageScripts.getDefaultScript(language,
-              region);
+          initialScript = DefaultLanguageScripts.getDefaultScript(language, region);
         }
         List<GwtLocale> thisGroup = new ArrayList<GwtLocale>();
         if (initialScript != null) {
           // Make sure the default script is listed first in the search list,
           // which ensures that zh_Hant appears before zh in the search list for
           // zh_TW.
-          thisGroup.add(factory.fromComponents(language, initialScript, region,
-              variant));
+          thisGroup.add(factory.fromComponents(language, initialScript, region, variant));
         }
         thisGroup.add(this);
         seen.addAll(thisGroup);
@@ -444,11 +446,10 @@ public class GwtLocaleImpl implements GwtLocale {
             if (locale.getRegion() != null) {
               addImmediateParentRegions(factory, locale, work);
             } else if (locale.getVariant() != null) {
-              work.add(factory.fromComponents(locale.getLanguage(),
-                  locale.getScript(), null, null));
+              work.add(
+                  factory.fromComponents(locale.getLanguage(), locale.getScript(), null, null));
             } else if (locale.getScript() != null) {
-              work.add(factory.fromComponents(locale.getLanguage(), null, null,
-                  null));
+              work.add(factory.fromComponents(locale.getLanguage(), null, null, null));
             }
             work.removeAll(seen);
             nextGroup.addAll(work);
@@ -466,10 +467,10 @@ public class GwtLocaleImpl implements GwtLocale {
   }
 
   /**
-   * Return a list of locales to search for, in order of preference.  The
-   * current locale is always first on the list.  Aliases are not included
-   * in the list -- use {@link #getAliases} to expand those.
-   * 
+   * Return a list of locales to search for, in order of preference. The current locale is always
+   * first on the list. Aliases are not included in the list -- use {@link #getAliases} to expand
+   * those.
+   *
    * @return inheritance list
    */
   public List<GwtLocale> getInheritanceChain() {
@@ -479,8 +480,7 @@ public class GwtLocaleImpl implements GwtLocale {
       inherits.add(factory.fromComponents(language, script, region, null));
     }
     if (region != null) {
-      addParentRegionLocales(factory, inherits, language, script, region,
-          null);
+      addParentRegionLocales(factory, inherits, language, script, region, null);
       inherits.add(factory.fromComponents(language, script, null, null));
     }
     if (script != null) {
@@ -538,10 +538,10 @@ public class GwtLocaleImpl implements GwtLocale {
   }
 
   /**
-   * Return true if this locale inherits from the specified locale.  Note that
-   * locale.inheritsFrom(locale) is false -- if you want that to be true, you
-   * should just use locale.getInheritanceChain().contains(x).
-   * 
+   * Return true if this locale inherits from the specified locale. Note that
+   * locale.inheritsFrom(locale) is false -- if you want that to be true, you should just use
+   * locale.getInheritanceChain().contains(x).
+   *
    * @param parent locale to test against
    * @return true if parent is an ancestor of this locale
    */
@@ -565,17 +565,19 @@ public class GwtLocaleImpl implements GwtLocale {
   }
 
   /**
-   * Checks if this locale uses the same script as another locale, taking into
-   * account default scripts.
-   * 
+   * Checks if this locale uses the same script as another locale, taking into account default
+   * scripts.
+   *
    * @param other
    * @return true if the scripts are the same
    */
   public boolean usesSameScript(GwtLocale other) {
-    String myScript = script != null ? script : DefaultLanguageScripts.getDefaultScript(language,
-        region);
-    String otherScript = other.getScript() != null ? other.getScript()
-        : DefaultLanguageScripts.getDefaultScript(other.getLanguage(), other.getRegion());
+    String myScript =
+        script != null ? script : DefaultLanguageScripts.getDefaultScript(language, region);
+    String otherScript =
+        other.getScript() != null
+            ? other.getScript()
+            : DefaultLanguageScripts.getDefaultScript(other.getLanguage(), other.getRegion());
     // two locales with an unspecified script and no default for the language
     // match only if the language is the same
     if (myScript == null) {
@@ -586,15 +588,14 @@ public class GwtLocaleImpl implements GwtLocale {
   }
 
   /**
-   * Remove aliases which are incompatible with the initial script provided or
-   * defaulted in a locale.
-   * 
+   * Remove aliases which are incompatible with the initial script provided or defaulted in a
+   * locale.
+   *
    * @param aliases
    * @param initialScript
    * @return copy of aliases with incompatible scripts removed
    */
-  private List<GwtLocale> filterBadScripts(List<GwtLocale> aliases,
-      String initialScript) {
+  private List<GwtLocale> filterBadScripts(List<GwtLocale> aliases, String initialScript) {
     if (initialScript == null) {
       return aliases;
     }

--- a/gwt-i18n-processor-util/src/main/java/org/gwtproject/i18n/processor/LocaleInfoContext.java
+++ b/gwt-i18n-processor-util/src/main/java/org/gwtproject/i18n/processor/LocaleInfoContext.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -15,20 +15,15 @@
  */
 package org.gwtproject.i18n.processor;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.gwtproject.ext.ConfigurationProperty;
 import org.gwtproject.ext.SelectionProperty;
 
-import java.util.HashMap;
-import java.util.Map;
-
-/**
- * A LocaleUtils specific context for caching.
- */
+/** A LocaleUtils specific context for caching. */
 public class LocaleInfoContext {
 
-  /**
-   * A key for lookup of computed values in a cache.
-   */
+  /** A key for lookup of computed values in a cache. */
   private static class CacheKey {
     private final SelectionProperty localeProperty;
     private final ConfigurationProperty runtimeLocaleProperty;
@@ -37,13 +32,14 @@ public class LocaleInfoContext {
 
     /**
      * Create a key for cache lookup.
-     * 
+     *
      * @param localeProperty "locale" property, must not be null
      * @param runtimeLocaleProperty "runtime.locales.new" property, must not be null
      * @param cookieProperty "locale.queryparam" property, must not be null
      * @param queryParamProperty "locale.cookie" property, must not be null
      */
-    public CacheKey(SelectionProperty localeProperty,
+    public CacheKey(
+        SelectionProperty localeProperty,
         ConfigurationProperty runtimeLocaleProperty,
         ConfigurationProperty queryParamProperty,
         ConfigurationProperty cookieProperty) {
@@ -83,22 +79,24 @@ public class LocaleInfoContext {
     }
   }
 
-  private final Map<CacheKey, LocaleUtils> localeUtilsCache = new HashMap<
-      CacheKey, LocaleUtils>();
+  private final Map<CacheKey, LocaleUtils> localeUtilsCache = new HashMap<CacheKey, LocaleUtils>();
 
-  public LocaleUtils getLocaleUtils(SelectionProperty localeProperty,
+  public LocaleUtils getLocaleUtils(
+      SelectionProperty localeProperty,
       ConfigurationProperty runtimeLocaleProperty,
-      ConfigurationProperty queryParamProp, ConfigurationProperty cookieProp) {
-    CacheKey key = new CacheKey(localeProperty, runtimeLocaleProperty,
-        queryParamProp, cookieProp);
+      ConfigurationProperty queryParamProp,
+      ConfigurationProperty cookieProp) {
+    CacheKey key = new CacheKey(localeProperty, runtimeLocaleProperty, queryParamProp, cookieProp);
     return localeUtilsCache.get(key);
   }
 
-  public void putLocaleUtils(SelectionProperty localeProperty,
-      ConfigurationProperty runtimeLocaleProperty, ConfigurationProperty queryParamProp,
-      ConfigurationProperty cookieProp, LocaleUtils localeUtils) {
-    CacheKey key = new CacheKey(localeProperty, runtimeLocaleProperty,
-        queryParamProp, cookieProp);
+  public void putLocaleUtils(
+      SelectionProperty localeProperty,
+      ConfigurationProperty runtimeLocaleProperty,
+      ConfigurationProperty queryParamProp,
+      ConfigurationProperty cookieProp,
+      LocaleUtils localeUtils) {
+    CacheKey key = new CacheKey(localeProperty, runtimeLocaleProperty, queryParamProp, cookieProp);
     localeUtilsCache.put(key, localeUtils);
   }
 }

--- a/gwt-i18n-processor-util/src/main/java/org/gwtproject/i18n/processor/LocaleUtils.java
+++ b/gwt-i18n-processor-util/src/main/java/org/gwtproject/i18n/processor/LocaleUtils.java
@@ -15,6 +15,9 @@
  */
 package org.gwtproject.i18n.processor;
 
+import java.util.*;
+import javax.annotation.processing.Messager;
+import javax.tools.Diagnostic;
 import org.gwtproject.ext.ConfigurationProperty;
 import org.gwtproject.ext.PropertyOracle;
 import org.gwtproject.ext.SelectionProperty;
@@ -22,234 +25,220 @@ import org.gwtproject.ext.UnableToCompleteException;
 import org.gwtproject.i18n.shared.GwtLocale;
 import org.gwtproject.i18n.shared.GwtLocaleFactory;
 
-import javax.annotation.processing.Messager;
-import javax.tools.Diagnostic;
-import java.util.*;
-
-/**
- * Utility methods for dealing with locales.
- */
+/** Utility methods for dealing with locales. */
 public class LocaleUtils {
-    private static final GwtLocaleFactoryImpl factory = new GwtLocaleFactoryImpl();
+  private static final GwtLocaleFactoryImpl factory = new GwtLocaleFactoryImpl();
 
-    /**
-     * The token representing the locale property controlling Localization.
-     */
-    // @VisibleForTesting
-    static final String PROP_LOCALE = "locale";
+  /** The token representing the locale property controlling Localization. */
+  // @VisibleForTesting
+  static final String PROP_LOCALE = "locale";
 
-    /**
-     * The config property identifying the URL query parameter name to possibly get
-     * the value of the locale property.
-     */
-    // @VisibleForTesting
-    static final String PROP_LOCALE_QUERY_PARAM = "locale.queryparam";
+  /**
+   * The config property identifying the URL query parameter name to possibly get the value of the
+   * locale property.
+   */
+  // @VisibleForTesting
+  static final String PROP_LOCALE_QUERY_PARAM = "locale.queryparam";
 
-    /**
-     * The config property identifying the cookie name to possibly get the value
-     * of the locale property.
-     */
-    // @VisibleForTesting
-    static final String PROP_LOCALE_COOKIE = "locale.cookie";
+  /**
+   * The config property identifying the cookie name to possibly get the value of the locale
+   * property.
+   */
+  // @VisibleForTesting
+  static final String PROP_LOCALE_COOKIE = "locale.cookie";
 
-    /**
-     * The token representing the runtime.locales.new configuration property.
-     */
-    // @VisibleForTesting
-    static final String PROP_RUNTIME_LOCALES = "runtime.locales.new";
+  /** The token representing the runtime.locales.new configuration property. */
+  // @VisibleForTesting
+  static final String PROP_RUNTIME_LOCALES = "runtime.locales.new";
 
-    /**
-     * Multiple generators need to access the shared cache state of
-     * LocaleInfoContext.
-     */
-    private static final WeakHashMap<ProcessorContext, LocaleInfoContext>
-            localeInfoCtxHolder = new WeakHashMap<ProcessorContext, LocaleInfoContext>();
+  /** Multiple generators need to access the shared cache state of LocaleInfoContext. */
+  private static final WeakHashMap<ProcessorContext, LocaleInfoContext> localeInfoCtxHolder =
+      new WeakHashMap<ProcessorContext, LocaleInfoContext>();
 
-    /**
-     * Create a new LocaleUtils instance for the given PropertyOracle.  Returned
-     * instances will be immutable and can be shared across threads.
-     *
-     * @param logger
-     * @param propertyOracle
-     * @return LocaleUtils instance
-     */
-    public static LocaleUtils getInstance(Messager logger,
-                                          PropertyOracle propertyOracle, ProcessorContext context) {
-        try {
-            SelectionProperty localeProp
-                    = propertyOracle.getSelectionProperty(logger, PROP_LOCALE);
-            ConfigurationProperty runtimeLocaleProp
-                    = propertyOracle.getConfigurationProperty(PROP_RUNTIME_LOCALES);
-            ConfigurationProperty queryParamProp
-                    = propertyOracle.getConfigurationProperty(PROP_LOCALE_QUERY_PARAM);
-            ConfigurationProperty cookieProp
-                    = propertyOracle.getConfigurationProperty(PROP_LOCALE_COOKIE);
-            LocaleInfoContext localeInfoCtx = new LocaleInfoContext();
-            LocaleUtils localeUtils = localeInfoCtx.getLocaleUtils(localeProp,
-                    runtimeLocaleProp, queryParamProp, cookieProp);
-            if (localeUtils == null) {
-                localeUtils = createInstance(localeProp, runtimeLocaleProp,
-                        queryParamProp, cookieProp);
-                localeInfoCtx.putLocaleUtils(localeProp, runtimeLocaleProp,
-                        queryParamProp, cookieProp, localeUtils);
-            }
-            return localeUtils;
-        } catch (UnableToCompleteException e) {
-            // if we don't have locale properties defined, just return a basic one
-            logger.printMessage(Diagnostic.Kind.WARNING,
-                    "Unable to get locale properties, using defaults"+ e.getMessage());
-            GwtLocale defaultLocale = factory.fromString("default");
-            Set<GwtLocale> allLocales = new HashSet<GwtLocale>();
-            allLocales.add(defaultLocale);
-            return new LocaleUtils(defaultLocale, allLocales, allLocales,
-                    Collections.<GwtLocale>emptySet(), null, null);
+  /**
+   * Create a new LocaleUtils instance for the given PropertyOracle. Returned instances will be
+   * immutable and can be shared across threads.
+   *
+   * @param logger
+   * @param propertyOracle
+   * @return LocaleUtils instance
+   */
+  public static LocaleUtils getInstance(
+      Messager logger, PropertyOracle propertyOracle, ProcessorContext context) {
+    try {
+      SelectionProperty localeProp = propertyOracle.getSelectionProperty(logger, PROP_LOCALE);
+      ConfigurationProperty runtimeLocaleProp =
+          propertyOracle.getConfigurationProperty(PROP_RUNTIME_LOCALES);
+      ConfigurationProperty queryParamProp =
+          propertyOracle.getConfigurationProperty(PROP_LOCALE_QUERY_PARAM);
+      ConfigurationProperty cookieProp =
+          propertyOracle.getConfigurationProperty(PROP_LOCALE_COOKIE);
+      LocaleInfoContext localeInfoCtx = new LocaleInfoContext();
+      LocaleUtils localeUtils =
+          localeInfoCtx.getLocaleUtils(localeProp, runtimeLocaleProp, queryParamProp, cookieProp);
+      if (localeUtils == null) {
+        localeUtils = createInstance(localeProp, runtimeLocaleProp, queryParamProp, cookieProp);
+        localeInfoCtx.putLocaleUtils(
+            localeProp, runtimeLocaleProp, queryParamProp, cookieProp, localeUtils);
+      }
+      return localeUtils;
+    } catch (UnableToCompleteException e) {
+      // if we don't have locale properties defined, just return a basic one
+      logger.printMessage(
+          Diagnostic.Kind.WARNING,
+          "Unable to get locale properties, using defaults" + e.getMessage());
+      GwtLocale defaultLocale = factory.fromString("default");
+      Set<GwtLocale> allLocales = new HashSet<GwtLocale>();
+      allLocales.add(defaultLocale);
+      return new LocaleUtils(
+          defaultLocale, allLocales, allLocales, Collections.<GwtLocale>emptySet(), null, null);
+    }
+  }
+
+  /**
+   * Get a shared GwtLocale factory so instances are cached between all uses.
+   *
+   * @return singleton GwtLocaleFactory instance.
+   */
+  public static GwtLocaleFactory getLocaleFactory() {
+    return factory;
+  }
+
+  private static LocaleUtils createInstance(
+      SelectionProperty localeProp,
+      ConfigurationProperty prop,
+      ConfigurationProperty queryParamProp,
+      ConfigurationProperty cookieProp) {
+    GwtLocale compileLocale = null;
+    Set<GwtLocale> allLocales = new HashSet<GwtLocale>();
+    Set<GwtLocale> allCompileLocales = new HashSet<GwtLocale>();
+    Set<GwtLocale> runtimeLocales = new HashSet<GwtLocale>();
+    String localeName = localeProp.getCurrentValue();
+    String queryParam = queryParamProp.getValues().get(0);
+    if (queryParam.length() == 0) {
+      queryParam = null;
+    }
+    String cookie = cookieProp.getValues().get(0);
+    if (cookie.length() == 0) {
+      cookie = null;
+    }
+    SortedSet<String> localeValues = localeProp.getPossibleValues();
+
+    GwtLocaleFactory factoryInstance = getLocaleFactory();
+    GwtLocale newCompileLocale = factoryInstance.fromString(localeName);
+    compileLocale = newCompileLocale;
+    for (String localeValue : localeValues) {
+      allCompileLocales.add(factoryInstance.fromString(localeValue));
+    }
+    allLocales.addAll(allCompileLocales);
+
+    List<String> rtLocaleNames = prop.getValues();
+    if (rtLocaleNames != null) {
+      for (String rtLocaleName : rtLocaleNames) {
+        GwtLocale rtLocale = factoryInstance.fromString(rtLocaleName);
+        if (rtLocale.isDefault()) {
+          continue;
         }
-    }
-
-    /**
-     * Get a shared GwtLocale factory so instances are cached between all uses.
-     *
-     * @return singleton GwtLocaleFactory instance.
-     */
-    public static GwtLocaleFactory getLocaleFactory() {
-        return factory;
-    }
-
-    private static LocaleUtils createInstance(SelectionProperty localeProp,
-                                              ConfigurationProperty prop, ConfigurationProperty queryParamProp,
-                                              ConfigurationProperty cookieProp) {
-        GwtLocale compileLocale = null;
-        Set<GwtLocale> allLocales = new HashSet<GwtLocale>();
-        Set<GwtLocale> allCompileLocales = new HashSet<GwtLocale>();
-        Set<GwtLocale> runtimeLocales = new HashSet<GwtLocale>();
-        String localeName = localeProp.getCurrentValue();
-        String queryParam = queryParamProp.getValues().get(0);
-        if (queryParam.length() == 0) {
-            queryParam = null;
+        for (GwtLocale search : rtLocale.getCompleteSearchList()) {
+          if (search.equals(compileLocale) && rtLocale.usesSameScript(compileLocale)) {
+            runtimeLocales.add(rtLocale);
+            allLocales.add(rtLocale);
+            break;
+          } else if (allCompileLocales.contains(search) && rtLocale.usesSameScript(search)) {
+            allLocales.add(rtLocale);
+            break;
+          }
         }
-        String cookie = cookieProp.getValues().get(0);
-        if (cookie.length() == 0) {
-            cookie = null;
-        }
-        SortedSet<String> localeValues = localeProp.getPossibleValues();
-
-        GwtLocaleFactory factoryInstance = getLocaleFactory();
-        GwtLocale newCompileLocale = factoryInstance.fromString(localeName);
-        compileLocale = newCompileLocale;
-        for (String localeValue : localeValues) {
-            allCompileLocales.add(factoryInstance.fromString(localeValue));
-        }
-        allLocales.addAll(allCompileLocales);
-
-        List<String> rtLocaleNames = prop.getValues();
-        if (rtLocaleNames != null) {
-            for (String rtLocaleName : rtLocaleNames) {
-                GwtLocale rtLocale = factoryInstance.fromString(rtLocaleName);
-                if (rtLocale.isDefault()) {
-                    continue;
-                }
-                for (GwtLocale search : rtLocale.getCompleteSearchList()) {
-                    if (search.equals(compileLocale) && rtLocale.usesSameScript(compileLocale)) {
-                        runtimeLocales.add(rtLocale);
-                        allLocales.add(rtLocale);
-                        break;
-                    } else if (allCompileLocales.contains(search) && rtLocale.usesSameScript(search)) {
-                        allLocales.add(rtLocale);
-                        break;
-                    }
-                }
-            }
-        }
-        return new LocaleUtils(compileLocale, allLocales, allCompileLocales,
-                runtimeLocales, queryParam, cookie);
+      }
     }
+    return new LocaleUtils(
+        compileLocale, allLocales, allCompileLocales, runtimeLocales, queryParam, cookie);
+  }
 
-    private static synchronized LocaleInfoContext getLocaleInfoCtx(
-            ProcessorContext context) {
+  private static synchronized LocaleInfoContext getLocaleInfoCtx(ProcessorContext context) {
 
-        LocaleInfoContext localeInfoCtx = localeInfoCtxHolder.get(context);
-        if (localeInfoCtx == null) {
-            localeInfoCtx = new LocaleInfoContext();
-            localeInfoCtxHolder.put(context, localeInfoCtx);
-        }
-        return localeInfoCtx;
+    LocaleInfoContext localeInfoCtx = localeInfoCtxHolder.get(context);
+    if (localeInfoCtx == null) {
+      localeInfoCtx = new LocaleInfoContext();
+      localeInfoCtxHolder.put(context, localeInfoCtx);
     }
+    return localeInfoCtx;
+  }
 
-    private final Set<GwtLocale> allCompileLocales;
+  private final Set<GwtLocale> allCompileLocales;
 
-    private final Set<GwtLocale> allLocales;
+  private final Set<GwtLocale> allLocales;
 
-    private final GwtLocale compileLocale;
+  private final GwtLocale compileLocale;
 
-    private final Set<GwtLocale> runtimeLocales;
+  private final Set<GwtLocale> runtimeLocales;
 
-    private final String queryParam;
+  private final String queryParam;
 
-    private final String cookie;
+  private final String cookie;
 
-    private LocaleUtils(GwtLocale compileLocale, Set<GwtLocale> allLocales,
-                        Set<GwtLocale> allCompileLocales, Set<GwtLocale> runtimeLocales,
-                        String queryParam, String cookie) {
-        this.compileLocale = compileLocale;
-        this.allLocales = Collections.unmodifiableSet(allLocales);
-        this.allCompileLocales = Collections.unmodifiableSet(allCompileLocales);
-        this.runtimeLocales = Collections.unmodifiableSet(runtimeLocales);
-        this.queryParam = queryParam;
-        this.cookie = cookie;
-    }
+  private LocaleUtils(
+      GwtLocale compileLocale,
+      Set<GwtLocale> allLocales,
+      Set<GwtLocale> allCompileLocales,
+      Set<GwtLocale> runtimeLocales,
+      String queryParam,
+      String cookie) {
+    this.compileLocale = compileLocale;
+    this.allLocales = Collections.unmodifiableSet(allLocales);
+    this.allCompileLocales = Collections.unmodifiableSet(allCompileLocales);
+    this.runtimeLocales = Collections.unmodifiableSet(runtimeLocales);
+    this.queryParam = queryParam;
+    this.cookie = cookie;
+  }
 
-    /**
-     * Returns the set of all compile-time locales.
-     *
-     * @return unmodifiable set of all compile-time locales
-     */
-    public Set<GwtLocale> getAllCompileLocales() {
-        return allCompileLocales;
-    }
+  /**
+   * Returns the set of all compile-time locales.
+   *
+   * @return unmodifiable set of all compile-time locales
+   */
+  public Set<GwtLocale> getAllCompileLocales() {
+    return allCompileLocales;
+  }
 
-    /**
-     * Returns the set of all available locales, whether compile-time locales or
-     * runtime locales.
-     *
-     * @return unmodifiable set of all locales
-     */
-    public Set<GwtLocale> getAllLocales() {
-        return allLocales;
-    }
+  /**
+   * Returns the set of all available locales, whether compile-time locales or runtime locales.
+   *
+   * @return unmodifiable set of all locales
+   */
+  public Set<GwtLocale> getAllLocales() {
+    return allLocales;
+  }
 
-    /**
-     * Returns the static compile-time locale for this permutation.
-     */
-    public GwtLocale getCompileLocale() {
-        return compileLocale;
-    }
+  /** Returns the static compile-time locale for this permutation. */
+  public GwtLocale getCompileLocale() {
+    return compileLocale;
+  }
 
-    /**
-     * Return the name of the cookie to potentially get the locale value from.
-     *
-     * @return the cookie name or null if none
-     */
-    public String getCookie() {
-        return cookie;
-    }
+  /**
+   * Return the name of the cookie to potentially get the locale value from.
+   *
+   * @return the cookie name or null if none
+   */
+  public String getCookie() {
+    return cookie;
+  }
 
-    /**
-     * Return the name of the URL query param to potentially get the locale value
-     * from.
-     *
-     * @return the URL query param or null if none
-     */
-    public String getQueryParam() {
-        return queryParam;
-    }
+  /**
+   * Return the name of the URL query param to potentially get the locale value from.
+   *
+   * @return the URL query param or null if none
+   */
+  public String getQueryParam() {
+    return queryParam;
+  }
 
-    /**
-     * Returns a list of locales which are children of the current compile-time
-     * locale.
-     *
-     * @return unmodifiable list of matching locales
-     */
-    public Set<GwtLocale> getRuntimeLocales() {
-        return runtimeLocales;
-    }
+  /**
+   * Returns a list of locales which are children of the current compile-time locale.
+   *
+   * @return unmodifiable list of matching locales
+   */
+  public Set<GwtLocale> getRuntimeLocales() {
+    return runtimeLocales;
+  }
 }

--- a/gwt-i18n-processor-util/src/main/java/org/gwtproject/i18n/processor/ProcessorContext.java
+++ b/gwt-i18n-processor-util/src/main/java/org/gwtproject/i18n/processor/ProcessorContext.java
@@ -1,49 +1,61 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.gwtproject.i18n.processor;
 
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
-import java.util.HashMap;
-import java.util.Map;
 
 public class ProcessorContext {
 
-    private final Messager messager;
-    private final Filer filer;
-    private final Types types;
-    private final Elements elements;
-    private final ProcessingEnvironment processingEnv;
+  private final Messager messager;
+  private final Filer filer;
+  private final Types types;
+  private final Elements elements;
+  private final ProcessingEnvironment processingEnv;
 
-    public ProcessorContext(ProcessingEnvironment processingEnv) {
-        this.messager = processingEnv.getMessager();
-        this.filer = processingEnv.getFiler();
-        this.types = processingEnv.getTypeUtils();
-        this.elements = processingEnv.getElementUtils();
-        this.processingEnv = processingEnv;
+  public ProcessorContext(ProcessingEnvironment processingEnv) {
+    this.messager = processingEnv.getMessager();
+    this.filer = processingEnv.getFiler();
+    this.types = processingEnv.getTypeUtils();
+    this.elements = processingEnv.getElementUtils();
+    this.processingEnv = processingEnv;
+  }
 
-    }
+  public Messager getMessager() {
+    return messager;
+  }
 
-    public Messager getMessager() {
-        return messager;
-    }
+  public Filer getFiler() {
+    return filer;
+  }
 
-    public Filer getFiler() {
-        return filer;
-    }
+  public Types getTypes() {
+    return types;
+  }
 
-    public Types getTypes() {
-        return types;
-    }
+  public Elements getElements() {
+    return elements;
+  }
 
-    public Elements getElements() {
-        return elements;
-    }
-
-    public Map<String, String> getOptions(){
-        return new HashMap<>(processingEnv.getOptions());
-    }
-
-
+  public Map<String, String> getOptions() {
+    return new HashMap<>(processingEnv.getOptions());
+  }
 }

--- a/gwt-i18n-processor-util/src/main/java/org/gwtproject/i18n/processor/RegionInheritance.java
+++ b/gwt-i18n-processor-util/src/main/java/org/gwtproject/i18n/processor/RegionInheritance.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2009 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -19,75 +19,72 @@ import java.util.*;
 
 /**
  * Generated maps of regions into parent regions, used for locale inheritance.
- * 
- * TODO(jat): make this actually be generated.
+ *
+ * <p>TODO(jat): make this actually be generated.
  */
 public class RegionInheritance {
 
   private static Map<String, String> parentRegionMap;
-  
+
   static {
     // TODO(jat): add support for multiple parent regions
     parentRegionMap = new HashMap<String, String>();
     // Data from CLDR supplementalData/territoryContainment
     // manually edited to remove multiple parents and non-UN data
     addChildren("001", "002", "009", "019", "142", "150"); // World
-    addChildren("011", "BF", "BJ", "CI", "CV", "GH", "GM", "GN", "GW", "LR",
-        "ML", "MR", "NE", "NG", "SH", "SL", "SN", "TG"); // Western", "Africa
-    addChildren("013", "BZ", "CR", "GT", "HN", "MX", "NI", "PA",
-        "SV"); // Central America
-    addChildren("014", "BI", "DJ", "ER", "ET", "KE", "KM", "MG", "MU", "MW",
-        "MZ", "RE", "RW", "SC", "SO", "TZ", "UG", "YT", "ZM",
-        "ZW"); // Eastern Africa
+    addChildren(
+        "011", "BF", "BJ", "CI", "CV", "GH", "GM", "GN", "GW", "LR", "ML", "MR", "NE", "NG", "SH",
+        "SL", "SN", "TG"); // Western", "Africa
+    addChildren("013", "BZ", "CR", "GT", "HN", "MX", "NI", "PA", "SV"); // Central America
+    addChildren(
+        "014", "BI", "DJ", "ER", "ET", "KE", "KM", "MG", "MU", "MW", "MZ", "RE", "RW", "SC", "SO",
+        "TZ", "UG", "YT", "ZM", "ZW"); // Eastern Africa
     addChildren("142", "030", "035", "143", "145", "034", "062"); // Asia
     addChildren("143", "TM", "TJ", "KG", "KZ", "UZ"); // Central Asia
-    addChildren("145", "AE", "AM", "AZ", "BH", "CY", "GE", "IL", "IQ", "JO",
-        "KW", "LB", "OM", "PS", "QA", "SA", "NT", "SY", "TR", "YE",
-        "YD"); // Western Asia
-    addChildren("015", "DZ", "EG", "EH", "LY", "MA", "SD",
-        "TN"); //Northern Africa
+    addChildren(
+        "145", "AE", "AM", "AZ", "BH", "CY", "GE", "IL", "IQ", "JO", "KW", "LB", "OM", "PS", "QA",
+        "SA", "NT", "SY", "TR", "YE", "YD"); // Western Asia
+    addChildren("015", "DZ", "EG", "EH", "LY", "MA", "SD", "TN"); // Northern Africa
     addChildren("150", "039", "151", "154", "155"); // Europe
-    addChildren("151", "BG", "BY", "CZ", "HU", "MD", "PL", "RO", "RU", "SU",
-        "SK", "UA"); // Eastern Europe
-    addChildren("154", "GG", "JE", "AX", "DK", "EE", "FI", "FO", "GB",
-        "IE", "IM", "IS", "LT", "LV", "NO", "SE", "SJ"); // Northern Europe
-    addChildren("155", "AT", "BE", "CH", "DE", "DD", "FR", "FX", "LI", "LU",
-        "MC", "NL"); // Western Europe
-    addChildren("017", "AO", "CD", "ZR", "CF", "CG", "CM", "GA", "GQ", "ST",
-        "TD"); // Middle Africa
+    addChildren(
+        "151", "BG", "BY", "CZ", "HU", "MD", "PL", "RO", "RU", "SU", "SK", "UA"); // Eastern Europe
+    addChildren(
+        "154", "GG", "JE", "AX", "DK", "EE", "FI", "FO", "GB", "IE", "IM", "IS", "LT", "LV", "NO",
+        "SE", "SJ"); // Northern Europe
+    addChildren(
+        "155", "AT", "BE", "CH", "DE", "DD", "FR", "FX", "LI", "LU", "MC", "NL"); // Western Europe
+    addChildren("017", "AO", "CD", "ZR", "CF", "CG", "CM", "GA", "GQ", "ST", "TD"); // Middle Africa
     addChildren("018", "BW", "LS", "NA", "SZ", "ZA"); // Southern Africa
     addChildren("019", "021", "419"); // Americas
     addChildren("002", "011", "014", "015", "017", "018"); // Africa
     addChildren("021", "BM", "CA", "GL", "PM", "US"); // Northern America
-    addChildren("029", "AG", "AI", "AN", "AW", "BB", "BL", "BS", "CU", "DM",
-        "DO", "GD", "GP", "HT", "JM", "KN", "KY", "LC", "MF", "MQ", "MS", "PR",
-        "TC", "TT", "VC", "VG", "VI"); // Caribbean
-    addChildren("030", "CN", "HK", "JP", "KP", "KR", "MN", "MO",
-        "TW"); // Eastern Asia
-    addChildren("035", "BN", "ID", "KH", "LA", "MM", "BU", "MY", "PH", "SG",
-        "TH", "TL", "TP", "VN"); // South-Eastern Asia
-    addChildren("039", "AD", "AL", "BA", "ES", "GI", "GR", "HR", "IT", "ME",
-        "MK", "MT", "CS", "RS", "PT", "SI", "SM", "VA",
-        "YU"); // Southern Europe
-    addChildren("419", "005", "013", "029"); //Latin America and the Caribbean
-    addChildren("005", "AR", "BO", "BR", "CL", "CO", "EC", "FK", "GF", "GY",
-        "PE", "PY", "SR", "UY", "VE"); // South America
+    addChildren(
+        "029", "AG", "AI", "AN", "AW", "BB", "BL", "BS", "CU", "DM", "DO", "GD", "GP", "HT", "JM",
+        "KN", "KY", "LC", "MF", "MQ", "MS", "PR", "TC", "TT", "VC", "VG", "VI"); // Caribbean
+    addChildren("030", "CN", "HK", "JP", "KP", "KR", "MN", "MO", "TW"); // Eastern Asia
+    addChildren(
+        "035", "BN", "ID", "KH", "LA", "MM", "BU", "MY", "PH", "SG", "TH", "TL", "TP",
+        "VN"); // South-Eastern Asia
+    addChildren(
+        "039", "AD", "AL", "BA", "ES", "GI", "GR", "HR", "IT", "ME", "MK", "MT", "CS", "RS", "PT",
+        "SI", "SM", "VA", "YU"); // Southern Europe
+    addChildren("419", "005", "013", "029"); // Latin America and the Caribbean
+    addChildren(
+        "005", "AR", "BO", "BR", "CL", "CO", "EC", "FK", "GF", "GY", "PE", "PY", "SR", "UY",
+        "VE"); // South America
     addChildren("053", "AU", "NF", "NZ"); // Australia and New Zealand
     addChildren("054", "FJ", "NC", "PG", "SB", "VU"); // Melanesia
     addChildren("057", "FM", "GU", "KI", "MH", "MP", "NR", "PW"); // Micronesia
-    addChildren("061", "AS", "CK", "NU", "PF", "PN", "TK", "TO", "TV", "WF",
-        "WS"); // Polynesia
-    addChildren("034", "AF", "BD", "BT", "IN", "IR", "LK", "MV", "NP",
-        "PK"); // Southern Asia
+    addChildren("061", "AS", "CK", "NU", "PF", "PN", "TK", "TO", "TV", "WF", "WS"); // Polynesia
+    addChildren("034", "AF", "BD", "BT", "IN", "IR", "LK", "MV", "NP", "PK"); // Southern Asia
     addChildren("009", "053", "054", "057", "061", "QO"); // Oceania
-    addChildren("QO", "AQ", "BV", "CC", "CX", "GS", "HM", "IO", "TF",
-        "UM"); // Outlying Oceania
+    addChildren("QO", "AQ", "BV", "CC", "CX", "GS", "HM", "IO", "TF", "UM"); // Outlying Oceania
   }
 
   /**
-   * Finds the first region which is a common parent of two regions.  If either
-   * region is null or if there is no common parent, returns null.  Otherwise,
-   * returns the region which contains both regions.
+   * Finds the first region which is a common parent of two regions. If either region is null or if
+   * there is no common parent, returns null. Otherwise, returns the region which contains both
+   * regions.
    *
    * @param region1
    * @param region2
@@ -98,24 +95,21 @@ public class RegionInheritance {
       return null;
     }
     List<String> parents1 = new ArrayList<String>();
-    for (String parent = region1; parent != null;
-        parent = parentRegionMap.get(parent)) {
+    for (String parent = region1; parent != null; parent = parentRegionMap.get(parent)) {
       parents1.add(parent);
     }
-    for (String parent = region2; parent != null;
-        parent = parentRegionMap.get(parent)) {
+    for (String parent = region2; parent != null; parent = parentRegionMap.get(parent)) {
       if (parents1.contains(parent)) {
         return parent;
       }
     }
     return null;
   }
-  
+
   /**
-   * Returns a set of all ancestors of a given region, including the region
-   * itself, in order of inheritance (ie, this region first, top-most region
-   * last).
-   * 
+   * Returns a set of all ancestors of a given region, including the region itself, in order of
+   * inheritance (ie, this region first, top-most region last).
+   *
    * @param child
    * @return list of ancestors
    */
@@ -139,8 +133,7 @@ public class RegionInheritance {
   }
 
   /**
-   * Returns the set of immediate parents of a given region, not including
-   * this region.
+   * Returns the set of immediate parents of a given region, not including this region.
    *
    * @param region
    * @return set of immediate parents
@@ -154,9 +147,9 @@ public class RegionInheritance {
   }
 
   /**
-   * Returns true if parent is equal to the child or is an ancestor.  If both
-   * are null, true is returned; otherwise if either is null false is returned.
-   * 
+   * Returns true if parent is equal to the child or is an ancestor. If both are null, true is
+   * returned; otherwise if either is null false is returned.
+   *
    * @param parent
    * @param child
    * @return true if parent is an ancestor of child
@@ -178,7 +171,7 @@ public class RegionInheritance {
   static Map<String, String> getInheritanceMap() {
     return parentRegionMap;
   }
-  
+
   private static void addChildren(String parent, String... children) {
     for (String child : children) {
       String oldParent = parentRegionMap.put(child, parent);

--- a/gwt-i18n-processor-util/src/main/java/org/gwtproject/i18n/processor/StepBuilder.java
+++ b/gwt-i18n-processor-util/src/main/java/org/gwtproject/i18n/processor/StepBuilder.java
@@ -1,15 +1,30 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.gwtproject.i18n.processor;
 
 import javax.annotation.processing.ProcessingEnvironment;
 
 public abstract class StepBuilder<T extends AbstractProcessingStep> {
 
-    protected ProcessingEnvironment processingEnv;
+  protected ProcessingEnvironment processingEnv;
 
-    public abstract T build();
+  public abstract T build();
 
-    public StepBuilder setProcessingEnv(ProcessingEnvironment processingEnv) {
-        this.processingEnv = processingEnv;
-        return this;
-    }
+  public StepBuilder setProcessingEnv(ProcessingEnvironment processingEnv) {
+    this.processingEnv = processingEnv;
+    return this;
+  }
 }

--- a/gwt-i18n/src/main/java/org/gwtproject/i18n/client/Constants.java
+++ b/gwt-i18n/src/main/java/org/gwtproject/i18n/client/Constants.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -18,111 +18,103 @@ package org.gwtproject.i18n.client;
 import java.lang.annotation.*;
 
 /**
- * A tag interface that facilitates locale-sensitive, compile-time binding of
- * constant values supplied from properties files. Using
- * <code>GWT.create(<i>class</i>)</code> to "instantiate" an interface that
- * extends <code>Constants</code> returns an instance of an automatically
- * generated subclass that is implemented using values from a property file
- * selected based on locale.
- * 
- * <p>
- * Locale is specified at run time using a meta tag or query string as described
- * for {@link org.gwtproject.i18n.client.Localizable}.
- * </p>
- * 
+ * A tag interface that facilitates locale-sensitive, compile-time binding of constant values
+ * supplied from properties files. Using <code>GWT.create(<i>class</i>)</code> to "instantiate" an
+ * interface that extends <code>Constants</code> returns an instance of an automatically generated
+ * subclass that is implemented using values from a property file selected based on locale.
+ *
+ * <p>Locale is specified at run time using a meta tag or query string as described for {@link
+ * org.gwtproject.i18n.client.Localizable}.
+ *
  * <h3>Extending <code>Constants</code></h3>
- * To use <code>Constants</code>, begin by defining an interface that extends
- * it. Each interface method is referred to as a <i>constant accessor</i>, and
- * its corresponding localized value is loaded based on the key for that method.
- * The default key is simply the unqualified name of the method, but can be specified
- * directly with an {@code @Key} annotation or a different generation method using
- * {@code @GenerateKeys}.  Also, the default value can be specified in an annotation
- * rather than a default properties file (and some key generators may require the value
- * to be given in the source file via annotations). For example,
- * 
- * {@example com.google.gwt.examples.i18n.NumberFormatConstants}
- * 
- * expects to find properties named <code>decimalSeparator</code> and
- * <code>thousandsSeparator</code> in an associated properties file. For
- * example, the following properties would be used for a German locale:
- * 
- * {@gwt.include com/google/gwt/examples/i18n/NumberFormatConstants_de_DE.properties}
- * 
- * <p>
- * The following example demonstrates how to use constant accessors defined in
- * the interface above:
- * 
- * {@example com.google.gwt.examples.i18n.NumberFormatConstantsExample#useNumberFormatConstants()}
- * </p>
- * 
- * <p>
- * Here is the same example using annotations to store the default values:
- * 
- * {@example com.google.gwt.examples.i18n.NumberFormatConstantsAnnot}
- * </p>
- * 
- * <p>
- * It is also possible to change the property name bound to a constant accessor
- * using the {@code @Key} annotation. For example,
- * {@example com.google.gwt.examples.i18n.NumberFormatConstantsWithAltKey}
- * 
- * would match the names of the following properties:
- * 
- * {@gwt.include com/google/gwt/examples/i18n/NumberFormatConstantsWithAltKey_en.properties}
- * </p>
- * 
+ *
+ * To use <code>Constants</code>, begin by defining an interface that extends it. Each interface
+ * method is referred to as a <i>constant accessor</i>, and its corresponding localized value is
+ * loaded based on the key for that method. The default key is simply the unqualified name of the
+ * method, but can be specified directly with an {@code @Key} annotation or a different generation
+ * method using {@code @GenerateKeys}. Also, the default value can be specified in an annotation
+ * rather than a default properties file (and some key generators may require the value to be given
+ * in the source file via annotations). For example,
+ *
+ * <p>{@example com.google.gwt.examples.i18n.NumberFormatConstants}
+ *
+ * <p>expects to find properties named <code>decimalSeparator</code> and <code>thousandsSeparator
+ * </code> in an associated properties file. For example, the following properties would be used for
+ * a German locale:
+ *
+ * <p>{@gwt.include com/google/gwt/examples/i18n/NumberFormatConstants_de_DE.properties}
+ *
+ * <p>The following example demonstrates how to use constant accessors defined in the interface
+ * above:
+ *
+ * <p>{@example
+ * com.google.gwt.examples.i18n.NumberFormatConstantsExample#useNumberFormatConstants()}
+ *
+ * <p>Here is the same example using annotations to store the default values:
+ *
+ * <p>{@example com.google.gwt.examples.i18n.NumberFormatConstantsAnnot}
+ *
+ * <p>It is also possible to change the property name bound to a constant accessor using the
+ * {@code @Key} annotation. For example, {@example
+ * com.google.gwt.examples.i18n.NumberFormatConstantsWithAltKey}
+ *
+ * <p>would match the names of the following properties:
+ *
+ * <p>{@gwt.include com/google/gwt/examples/i18n/NumberFormatConstantsWithAltKey_en.properties}
+ *
  * <h3>Defining Constant Accessors</h3>
+ *
  * Constant accessors must be of the form
- * 
+ *
  * <pre>T methodName()</pre>
- * 
+ *
  * where <code>T</code> is one of the return types in the following table:
- * 
+ *
  * <table>
  * <tr>
  * <th><nobr>If the return type is...&#160;&#160;&#160;</nobr></th>
  * <th>The property value is interpreted as...</th>
  * <th>Annotation to use for default value</th>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>String</code></td>
  * <td>A plain string value</td>
  * <td>{@code @DefaultStringValue}</td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>String[]</code></td>
  * <td>A comma-separated array of strings; use '<code>\\,</code>' to escape
  * commas</td>
  * <td>{@code @DefaultStringArrayValue}</td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>int</code></td>
  * <td>An <code>int</code> value, checked during compilation</td>
  * <td>{@code @DefaultIntValue}</td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>float</code></td>
  * <td>A <code>float</code> value, checked during compilation</td>
  * <td>{@code @DefaultFloatValue}</td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>double</code></td>
  * <td>A <code>double</code> value, checked during compilation</td>
  * <td>{@code @DefaultDoubleValue}</td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>boolean</code></td>
  * <td>A <code>boolean</code> value ("true" or "false"), checked during
  * compilation</td>
  * <td>{@code @DefaultBooleanValue}</td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>Map</code></td>
  * <td>A comma-separated list of property names, each of which is a key into a
@@ -130,109 +122,99 @@ import java.lang.annotation.*;
  * having named by that key</td>
  * <td>{@code @DefaultStringMapValue}</td>
  * </tr>
- * 
+ *
  * </table>
- * 
- * <p>
- * As an example of a <code>Map</code>, for the following property file:
- * </p>
- * 
+ *
+ * <p>As an example of a <code>Map</code>, for the following property file:
+ *
  * <pre>
  * a = X
  * b = Y
  * c = Z
  * someMap = a, b, c
  * </pre>
- * 
- * <p>
- * the constant accessor <code>someMap()</code> would return a
- * <code>Map</code> that maps <code>"a"</code> onto <code>"X"</code>,
- * <code>"b"</code> onto <code>"Y"</code>, and <code>"c"</code> onto
- * <code>"Z"</code>. Iterating through this <code>Map</code> will return
- * the keys or entries in declaration order.
- * </p>
- * 
- * <p>The benefit of using annotations, aside from not having to switch to
- * a different file to enter the default values, is that you can make use
- * of compile-time constants and not worrying about quoting commas.  For example:
- * 
- * {@example com.google.gwt.examples.i18n.AnnotConstants}
- * </p>
- * 
+ *
+ * <p>the constant accessor <code>someMap()</code> would return a <code>Map</code> that maps <code>
+ * "a"</code> onto <code>"X"</code>, <code>"b"</code> onto <code>"Y"</code>, and <code>"c"</code>
+ * onto <code>"Z"</code>. Iterating through this <code>Map</code> will return the keys or entries in
+ * declaration order.
+ *
+ * <p>The benefit of using annotations, aside from not having to switch to a different file to enter
+ * the default values, is that you can make use of compile-time constants and not worrying about
+ * quoting commas. For example:
+ *
+ * <p>{@example com.google.gwt.examples.i18n.AnnotConstants}
+ *
  * <h3>Binding to Properties Files</h3>
- * If an interface <code>org.example.foo.Intf</code> extends
- * <code>Constants</code> and the following code is used to create an object
- * from <code>Intf</code> as follows:
- * 
+ *
+ * If an interface <code>org.example.foo.Intf</code> extends <code>Constants</code> and the
+ * following code is used to create an object from <code>Intf</code> as follows:
+ *
  * <pre class="code">Intf constants = (Intf)GWT.create(Intf.class);</pre>
- * 
- * then <code>constants</code> will be assigned an instance of a generated
- * class whose constant accessors are implemented by extracting values from a
- * set of matching properties files. Property values are sought using a
- * best-match algorithm, and candidate properties files are those which (1)
- * reside in the same package as the interface (<code>org/example/foo/</code>),
- * (2) have a base filename matching the interface name (<code>Intf</code>),
- * and (3) have a suffix that most closely matches the locale. Suffixes are
- * matched as follows:
- * 
+ *
+ * then <code>constants</code> will be assigned an instance of a generated class whose constant
+ * accessors are implemented by extracting values from a set of matching properties files. Property
+ * values are sought using a best-match algorithm, and candidate properties files are those which
+ * (1) reside in the same package as the interface (<code>org/example/foo/</code>), (2) have a base
+ * filename matching the interface name (<code>Intf</code>), and (3) have a suffix that most closely
+ * matches the locale. Suffixes are matched as follows:
+ *
  * <table>
- * 
+ *
  * <tr>
  * <th align='left'><nobr>If <code>locale</code> is...&#160;&#160;</nobr></th>
  * <th align='left'>The properties file that binds to
  * <code>org.example.foo.Intf</code> is...</th>
  * </tr>
- * 
+ *
  * <tr>
  * <td><i>unspecified</i></td>
  * <td><code>org/example/foo/Intf.properties</code></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>x</code></td>
  * <td><code>org/example/foo/Intf_x.properties</code> if it exists and
  * defines the property being sought, otherwise treated as if
  * <code>locale</code> were <i>unspecified</i></td>
  * </tr>
- * 
+ *
  * <tr>
  * <td><code>x_Y</code></td>
  * <td><code>org/example/foo/Intf_x_Y.properties</code> if it exists and
  * defines the property being sought, otherwise treated as if
  * <code>locale</code> were <code>x</code></td>
  * </tr>
- * 
- * </table> where <code>x</code> and <code>Y</code> are language and locale
- * codes, as described in the documentation for
- * {@link org.gwtproject.i18n.client.Localizable}.  Note that default values
- * supplied in the source file in annotations take precedence over those in
- * the default properties file, if it is also present.
- * 
- * <p>
- * Note that the matching algorithm is applied independently for each constant
- * accessor. It is therefore possible to create a hierarchy of related
- * properties files such that an unlocalized properties file acts as a baseline,
- * and locale-specific properties files may redefine a subset of those
- * properties, relying on the matching algorithm to prefer localized properties
- * while still finding unlocalized properties.
- * </p>
- * 
+ *
+ * </table>
+ *
+ * where <code>x</code> and <code>Y</code> are language and locale codes, as described in the
+ * documentation for {@link org.gwtproject.i18n.client.Localizable}. Note that default values
+ * supplied in the source file in annotations take precedence over those in the default properties
+ * file, if it is also present.
+ *
+ * <p>Note that the matching algorithm is applied independently for each constant accessor. It is
+ * therefore possible to create a hierarchy of related properties files such that an unlocalized
+ * properties file acts as a baseline, and locale-specific properties files may redefine a subset of
+ * those properties, relying on the matching algorithm to prefer localized properties while still
+ * finding unlocalized properties.
+ *
  * <h3>Required Module</h3>
- * Modules that use this interface should inherit
- * <code>org.gwtproject.i18n.I18N</code>.
- * 
- * {@gwt.include com/google/gwt/examples/i18n/InheritsExample.gwt.xml}
- * 
+ *
+ * Modules that use this interface should inherit <code>org.gwtproject.i18n.I18N</code>.
+ *
+ * <p>{@gwt.include com/google/gwt/examples/i18n/InheritsExample.gwt.xml}
+ *
  * <h3>Note</h3>
- * You should not directly implement this interface or interfaces derived from
- * it since an implementation is generated automatically when message interfaces
- * are created using {@link com.google.gwt.core.client.GWT#create(Class)}.
+ *
+ * You should not directly implement this interface or interfaces derived from it since an
+ * implementation is generated automatically when message interfaces are created using {@link
+ * com.google.gwt.core.client.GWT#create(Class)}.
  */
 public interface Constants extends LocalizableResource {
   /**
-   * Default boolean value to be used if no translation is found (and also used as the
-   * source for translation).  No quoting (other than normal Java string quoting)
-   * is done.
+   * Default boolean value to be used if no translation is found (and also used as the source for
+   * translation). No quoting (other than normal Java string quoting) is done.
    */
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)
@@ -242,9 +224,8 @@ public interface Constants extends LocalizableResource {
   }
 
   /**
-   * Default double value to be used if no translation is found (and also used as the
-   * source for translation).  No quoting (other than normal Java string quoting)
-   * is done.
+   * Default double value to be used if no translation is found (and also used as the source for
+   * translation). No quoting (other than normal Java string quoting) is done.
    */
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)
@@ -254,9 +235,8 @@ public interface Constants extends LocalizableResource {
   }
 
   /**
-   * Default float value to be used if no translation is found (and also used as the
-   * source for translation).  No quoting (other than normal Java string quoting)
-   * is done.
+   * Default float value to be used if no translation is found (and also used as the source for
+   * translation). No quoting (other than normal Java string quoting) is done.
    */
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)
@@ -266,9 +246,8 @@ public interface Constants extends LocalizableResource {
   }
 
   /**
-   * Default integer value to be used if no translation is found (and also used as the
-   * source for translation).  No quoting (other than normal Java string quoting)
-   * is done.
+   * Default integer value to be used if no translation is found (and also used as the source for
+   * translation). No quoting (other than normal Java string quoting) is done.
    */
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)
@@ -278,12 +257,11 @@ public interface Constants extends LocalizableResource {
   }
 
   /**
-   * Default string array value to be used if no translation is found (and also
-   * used as the source for translation). No quoting (other than normal Java
-   * string quoting) is done.
-   * 
-   * Note that in the corresponding properties/etc file, commas are used to separate
-   * elements of the array unless they are preceded with a backslash.
+   * Default string array value to be used if no translation is found (and also used as the source
+   * for translation). No quoting (other than normal Java string quoting) is done.
+   *
+   * <p>Note that in the corresponding properties/etc file, commas are used to separate elements of
+   * the array unless they are preceded with a backslash.
    */
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)
@@ -293,31 +271,26 @@ public interface Constants extends LocalizableResource {
   }
 
   /**
-   * Default string map value to be used if no translation is found (and also
-   * used as the source for translation). No quoting (other than normal Java
-   * string quoting) is done.  The strings for the map are supplied in key/value
-   * pairs.
-   * 
-   * Note that in the corresponding properties/etc file, new keys can be supplied
-   * with the name of the method (or its corresponding key) listing the set of keys
-   * for the map separated by commas (commas can be part of the keys by preceding
-   * them with a backslash).  In either case, further entries have keys matching
-   * the key in this map.
+   * Default string map value to be used if no translation is found (and also used as the source for
+   * translation). No quoting (other than normal Java string quoting) is done. The strings for the
+   * map are supplied in key/value pairs.
+   *
+   * <p>Note that in the corresponding properties/etc file, new keys can be supplied with the name
+   * of the method (or its corresponding key) listing the set of keys for the map separated by
+   * commas (commas can be part of the keys by preceding them with a backslash). In either case,
+   * further entries have keys matching the key in this map.
    */
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)
   @Documented
   public @interface DefaultStringMapValue {
-    /**
-     * Must be key-value pairs.
-     */
+    /** Must be key-value pairs. */
     String[] value();
   }
 
   /**
-   * Default string value to be used if no translation is found (and also used as the
-   * source for translation).  No quoting (other than normal Java string quoting)
-   * is done.
+   * Default string value to be used if no translation is found (and also used as the source for
+   * translation). No quoting (other than normal Java string quoting) is done.
    */
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)

--- a/gwt-i18n/src/main/java/org/gwtproject/i18n/client/ConstantsWithLookup.java
+++ b/gwt-i18n/src/main/java/org/gwtproject/i18n/client/ConstantsWithLookup.java
@@ -19,99 +19,94 @@ import java.util.Map;
 import java.util.MissingResourceException;
 
 /**
- * Like {@link com.google.gwt.i18n.client.Constants}, a tag interface that
- * facilitates locale-sensitive, compile-time binding of constant values
- * supplied from properties files with the added ability to look up constants at
- * runtime with a string key.
+ * Like {@link com.google.gwt.i18n.client.Constants}, a tag interface that facilitates
+ * locale-sensitive, compile-time binding of constant values supplied from properties files with the
+ * added ability to look up constants at runtime with a string key.
  *
- * <p>
- * <code>ConstantsWithLookup</code> extends
- * {@link com.google.gwt.i18n.client.Constants} and is identical in behavior,
- * adding only a family of special-purpose lookup methods such as
- * {@link ConstantsWithLookup#getString(String)}.
- * </p>
+ * <p><code>ConstantsWithLookup</code> extends {@link com.google.gwt.i18n.client.Constants} and is
+ * identical in behavior, adding only a family of special-purpose lookup methods such as {@link
+ * ConstantsWithLookup#getString(String)}.
  *
- * <p>
- * It is generally preferable to extend <code>Constants</code> rather than
- * <code>ConstantsWithLookup</code> because <code>ConstantsWithLookup</code>
- * forces all constants to be retained in the compiled script, preventing the
- * GWT compiler from pruning unused constant accessors.
- * </p>
+ * <p>It is generally preferable to extend <code>Constants</code> rather than <code>
+ * ConstantsWithLookup</code> because <code>ConstantsWithLookup</code> forces all constants to be
+ * retained in the compiled script, preventing the GWT compiler from pruning unused constant
+ * accessors.
  *
  * <h3>Required Module</h3>
- * Modules that use this interface should inherit
- * <code>com.google.gwt.i18n.I18N</code>.
  *
- * {@gwt.include com/google/gwt/examples/i18n/InheritsExample.gwt.xml}
+ * Modules that use this interface should inherit <code>com.google.gwt.i18n.I18N</code>.
+ *
+ * <p>{@gwt.include com/google/gwt/examples/i18n/InheritsExample.gwt.xml}
  *
  * <h3>Note</h3>
- * You should not directly implement this interface or interfaces derived from
- * it since an implementation is generated automatically when message interfaces
- * are created using {@link com.google.gwt.core.client.GWT#create(Class)}.
+ *
+ * You should not directly implement this interface or interfaces derived from it since an
+ * implementation is generated automatically when message interfaces are created using {@link
+ * com.google.gwt.core.client.GWT#create(Class)}.
  *
  * @see com.google.gwt.i18n.client.Constants
  */
 public interface ConstantsWithLookup extends Constants {
-    /**
-     * Look up <code>boolean</code> by method name.
-     *
-     * @param methodName method name
-     * @return boolean returned by method
-     * @throws MissingResourceException if methodName is not valid
-     */
-    boolean getBoolean(String methodName) throws MissingResourceException;
+  /**
+   * Look up <code>boolean</code> by method name.
+   *
+   * @param methodName method name
+   * @return boolean returned by method
+   * @throws MissingResourceException if methodName is not valid
+   */
+  boolean getBoolean(String methodName) throws MissingResourceException;
 
-    /**
-     * Look up <code>double</code> by method name.
-     *
-     * @param methodName method name
-     * @return double returned by method
-     * @throws MissingResourceException if methodName is not valid
-     */
-    double getDouble(String methodName) throws MissingResourceException;
+  /**
+   * Look up <code>double</code> by method name.
+   *
+   * @param methodName method name
+   * @return double returned by method
+   * @throws MissingResourceException if methodName is not valid
+   */
+  double getDouble(String methodName) throws MissingResourceException;
 
-    /**
-     * Look up <code>float</code> by method name.
-     *
-     * @param methodName method name
-     * @return float returned by method
-     * @throws MissingResourceException if methodName is not valid
-     */
-    float getFloat(String methodName) throws MissingResourceException;
+  /**
+   * Look up <code>float</code> by method name.
+   *
+   * @param methodName method name
+   * @return float returned by method
+   * @throws MissingResourceException if methodName is not valid
+   */
+  float getFloat(String methodName) throws MissingResourceException;
 
-    /**
-     * Look up <code>int</code> by method name.
-     *
-     * @param methodName method name
-     * @return int returned by method
-     * @throws MissingResourceException if methodName is not valid
-     */
-    int getInt(String methodName) throws MissingResourceException;
+  /**
+   * Look up <code>int</code> by method name.
+   *
+   * @param methodName method name
+   * @return int returned by method
+   * @throws MissingResourceException if methodName is not valid
+   */
+  int getInt(String methodName) throws MissingResourceException;
 
-    /**
-     * Look up <code>Map</code> by method name.
-     *
-     * @param methodName method name
-     * @return Map returned by method
-     * @throws MissingResourceException if methodName is not valid
-     */
-    Map<String, String> getMap(String methodName) throws MissingResourceException;
+  /**
+   * Look up <code>Map</code> by method name.
+   *
+   * @param methodName method name
+   * @return Map returned by method
+   * @throws MissingResourceException if methodName is not valid
+   */
+  Map<String, String> getMap(String methodName) throws MissingResourceException;
 
-    /**
-     * Look up <code>String</code> by method name.
-     *
-     * @param methodName method name
-     * @return String returned by method
-     * @throws MissingResourceException if methodName is not valid
-     */
-    String getString(String methodName) throws MissingResourceException;
+  /**
+   * Look up <code>String</code> by method name.
+   *
+   * @param methodName method name
+   * @return String returned by method
+   * @throws MissingResourceException if methodName is not valid
+   */
+  String getString(String methodName) throws MissingResourceException;
 
-    /**
-     * Look up <code>String[]</code> by method name.
-     *
-     * @param methodName method name
-     * @return String[] returned by method
-     * @throws MissingResourceException if methodName is not valid
-     */
-    String[] getStringArray(String methodName) throws MissingResourceException;
+  /**
+   * Look up <code>String[]</code> by method name.
+   *
+   * @param methodName method name
+   * @return String[] returned by method
+   * @throws MissingResourceException if methodName is not valid
+   */
+  String[] getStringArray(String methodName) throws MissingResourceException;
 }

--- a/gwt-i18n/src/main/java/org/gwtproject/i18n/client/Localizable.java
+++ b/gwt-i18n/src/main/java/org/gwtproject/i18n/client/Localizable.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -17,9 +17,8 @@ package org.gwtproject.i18n.client;
 
 /**
  * For backwards compatibility only.
- * 
- * deprecated use {@link org.gwtproject.i18n.shared.Localizable} instead
+ *
+ * <p>deprecated use {@link org.gwtproject.i18n.shared.Localizable} instead
  */
 @Deprecated
-public interface Localizable extends org.gwtproject.i18n.shared.Localizable {
-}
+public interface Localizable extends org.gwtproject.i18n.shared.Localizable {}

--- a/gwt-i18n/src/main/java/org/gwtproject/i18n/client/LocalizableResource.java
+++ b/gwt-i18n/src/main/java/org/gwtproject/i18n/client/LocalizableResource.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2008 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -19,23 +19,20 @@ import java.lang.annotation.*;
 
 /**
  * This is the common superinterface to Messages and Constants.
- * 
- * Each (and the Constants subinterface ConstantsWithLookup) provide
- * compile-time localization of various forms of data.  Messages is
- * used for <code>MessageFormat</code>-style strings which can have
- * parameters (including support for plural forms), while Constants
- * can be other types, have simplified quoting requirements, and do
- * not take any parameters.
- * 
- * The annotations defined here are common to both -- see the individual
- * subinterfaces for additional annotations which apply only to each
- * one.
+ *
+ * <p>Each (and the Constants subinterface ConstantsWithLookup) provide compile-time localization of
+ * various forms of data. Messages is used for <code>MessageFormat</code>-style strings which can
+ * have parameters (including support for plural forms), while Constants can be other types, have
+ * simplified quoting requirements, and do not take any parameters.
+ *
+ * <p>The annotations defined here are common to both -- see the individual subinterfaces for
+ * additional annotations which apply only to each one.
  */
 public interface LocalizableResource extends Localizable {
-  
+
   /**
-   * Specifies the default locale for messages in this file.  If not
-   * specified, the default is <code>DEFAULT_LOCALE</code>.
+   * Specifies the default locale for messages in this file. If not specified, the default is <code>
+   * DEFAULT_LOCALE</code>.
    */
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.TYPE)
@@ -46,10 +43,7 @@ public interface LocalizableResource extends Localizable {
     String value() default DEFAULT_LOCALE;
   }
 
-  /**
-   * Specifies a description of the string to be translated, such as a note
-   * about the context.
-   */
+  /** Specifies a description of the string to be translated, such as a note about the context. */
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)
   public @interface Description {
@@ -57,81 +51,69 @@ public interface LocalizableResource extends Localizable {
   }
 
   /**
-   * Requests that a translation source file be generated from the annotated
-   * interface.  The file type is determined by the format argument, and the
-   * file name by the optional fileName argument.  Some file formats support
-   * aggregating messages from multiple interfaces into one file, while others
-   * do not; also, additional parameters may be specified via format-specific
-   * annotations -- see the documentation of the MessageCatalogFormat implementation
-   * for details.
-   * 
-   * Examples:
+   * Requests that a translation source file be generated from the annotated interface. The file
+   * type is determined by the format argument, and the file name by the optional fileName argument.
+   * Some file formats support aggregating messages from multiple interfaces into one file, while
+   * others do not; also, additional parameters may be specified via format-specific annotations --
+   * see the documentation of the MessageCatalogFormat implementation for details.
+   *
+   * <p>Examples:
+   *
    * <ul>
-   * <li>&#64;Generate(format = "org.gwtproject.i18n.server.PropertyCatalogFactory")
-   * <br>generates properties files for all locales, and the names will be
-   *      of the form MyMessages_locale.properties
-   * <li>&#64;Generate(format = {"com.example.ProprietaryFormat1",
-   *    "com.example.ProprietaryFormat2"},
-   *    fileName = "myapp_translate_source", locales = {"default"})
-   * <br>generates default files in two proprietary formats, with filenames like
-   *      myapp_translate_source.p1 and myapp_translate_source.p2
-   * </pre></code>  
+   *   <li>&#64;Generate(format = "org.gwtproject.i18n.server.PropertyCatalogFactory") <br>
+   *       generates properties files for all locales, and the names will be of the form
+   *       MyMessages_locale.properties
+   *   <li>&#64;Generate(format = {"com.example.ProprietaryFormat1",
+   *       "com.example.ProprietaryFormat2"}, fileName = "myapp_translate_source", locales =
+   *       {"default"}) <br>
+   *       generates default files in two proprietary formats, with filenames like
+   *       myapp_translate_source.p1 and myapp_translate_source.p2 </pre>
+   *       </code>
    */
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.TYPE)
   public @interface Generate {
 
-    /**
-     * Placeholder used to detect that no value was supplied for the fileName
-     * parameter.
-     */
+    /** Placeholder used to detect that no value was supplied for the fileName parameter. */
     String DEFAULT = "[default]";
-    
+
     /**
-     * Fully-qualified class names of the generator classes. Each class must
-     * implement org.gwtproject.i18n.server.MessageCatalogFactory
-     * (org.gwtproject.i18n.rebind.format.MessageCatalogFormat still works, but
-     * is deprecated).
-     * 
-     * Strings are used here instead of class literals because the generators
-     * will likely contain non-translatable code and thus can't be referenced
-     * from translatable code directly.
-     * 
-     * Each generator may define additional annotations to supply other
-     * necessary parameters.
+     * Fully-qualified class names of the generator classes. Each class must implement
+     * org.gwtproject.i18n.server.MessageCatalogFactory
+     * (org.gwtproject.i18n.rebind.format.MessageCatalogFormat still works, but is deprecated).
+     *
+     * <p>Strings are used here instead of class literals because the generators will likely contain
+     * non-translatable code and thus can't be referenced from translatable code directly.
+     *
+     * <p>Each generator may define additional annotations to supply other necessary parameters.
      */
     String[] format();
 
     /**
-     * A platform-specific filename for output. If not present, the file will be
-     * named based on the fully-qualified name of the annotated interface. File
-     * names without a slash are given a relative name based on the
-     * fully-qualified package name of the annotated interface. Relative
-     * pathnames are generated in the auxiliary module directory (moduleName-aux
-     * in the output directory, which is specified by the "-out" flag to the
-     * compiler, or the current directory if not present) -- absolute path names
-     * are not allowed. Unless exactly one locale is specified for locales (not
-     * just only one locale happened to be compiled for), the locale will be
-     * appended to the name (such as _default [for the default locale], _en_US,
-     * etc) as well as the proper extension for the specified format.
-     * 
-     * Note that if multiple generators are used, they will have the same base
-     * filename so the extensions must be different.
+     * A platform-specific filename for output. If not present, the file will be named based on the
+     * fully-qualified name of the annotated interface. File names without a slash are given a
+     * relative name based on the fully-qualified package name of the annotated interface. Relative
+     * pathnames are generated in the auxiliary module directory (moduleName-aux in the output
+     * directory, which is specified by the "-out" flag to the compiler, or the current directory if
+     * not present) -- absolute path names are not allowed. Unless exactly one locale is specified
+     * for locales (not just only one locale happened to be compiled for), the locale will be
+     * appended to the name (such as _default [for the default locale], _en_US, etc) as well as the
+     * proper extension for the specified format.
+     *
+     * <p>Note that if multiple generators are used, they will have the same base filename so the
+     * extensions must be different.
      */
     String fileName() default DEFAULT;
-    
+
     /**
-     * A list of locales for which to generate this output file.  If no locales
-     * are specified, all locales for which the application is compiled for will
-     * be generated. Note that the default locale is "default".
+     * A list of locales for which to generate this output file. If no locales are specified, all
+     * locales for which the application is compiled for will be generated. Note that the default
+     * locale is "default".
      */
     String[] locales() default {};
   }
 
-  /**
-   * Annotation indicating this is a generated file and the source file it was
-   * generated from. 
-   */
+  /** Annotation indicating this is a generated file and the source file it was generated from. */
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.TYPE)
   public @interface GeneratedFrom {
@@ -139,11 +121,10 @@ public interface LocalizableResource extends Localizable {
   }
 
   /**
-   * Requests that the keys for messages be generated automatically.  If the
-   * annotation is supplied with no value, the default is to use an MD5 hash of
-   * the text and meaning.  If this annotation is not supplied, the keys will be
-   * the unqualified method names.
-   * 
+   * Requests that the keys for messages be generated automatically. If the annotation is supplied
+   * with no value, the default is to use an MD5 hash of the text and meaning. If this annotation is
+   * not supplied, the keys will be the unqualified method names.
+   *
    * <p>The value is either the name of an inner class of {@code KeyGenerator} or the
    * fully-qualified class name of some implementation of {@code KeyGenerator}.
    */
@@ -154,9 +135,8 @@ public interface LocalizableResource extends Localizable {
   }
 
   /**
-   * The key used for lookup of translated strings.  If not present, the
-   * key will be generated based on the {@code @GenerateKeys} annotation,
-   * or the unqualified method name if it is not present.
+   * The key used for lookup of translated strings. If not present, the key will be generated based
+   * on the {@code @GenerateKeys} annotation, or the unqualified method name if it is not present.
    */
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)
@@ -165,8 +145,8 @@ public interface LocalizableResource extends Localizable {
   }
 
   /**
-   * Specifies the meaning of the translated string.  For example, to
-   * distinguish between multiple meanings of a word or phrase.
+   * Specifies the meaning of the translated string. For example, to distinguish between multiple
+   * meanings of a word or phrase.
    */
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)

--- a/gwt-i18n/src/main/java/org/gwtproject/i18n/client/Messages.java
+++ b/gwt-i18n/src/main/java/org/gwtproject/i18n/client/Messages.java
@@ -1,109 +1,103 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.gwtproject.i18n.client;
 
 import java.lang.annotation.*;
 
 /**
- * A tag interface that facilitates locale-sensitive, compile-time binding of
- * messages supplied from various sources.Using
- * <code>GWT.create(<i>class</i>)</code> to "instantiate" an interface that
- * extends <code>Messages</code> returns an instance of an automatically
- * generated subclass that is implemented using message templates selected based
- * on locale. Message templates are based on a subset of the format used by <a
- * href="http://download.oracle.com/javase/1.5.0/docs/api/java/text/MessageFormat.html">
- * <code>MessageFormat</code></a>.  Note in particular that single quotes are
- * used to quote other characters, and should be doubled for a literal single
- * quote.
+ * A tag interface that facilitates locale-sensitive, compile-time binding of messages supplied from
+ * various sources.Using <code>GWT.create(<i>class</i>)</code> to "instantiate" an interface that
+ * extends <code>Messages</code> returns an instance of an automatically generated subclass that is
+ * implemented using message templates selected based on locale. Message templates are based on a
+ * subset of the format used by <a
+ * href="http://download.oracle.com/javase/1.5.0/docs/api/java/text/MessageFormat.html"><code>
+ * MessageFormat</code></a>. Note in particular that single quotes are used to quote other
+ * characters, and should be doubled for a literal single quote.
  *
- * <p>
- * Locale is specified at run time using a meta tag or query string as described
- * for {@link org.gwtproject.i18n.client.Localizable}.
- * </p>
+ * <p>Locale is specified at run time using a meta tag or query string as described for {@link
+ * org.gwtproject.i18n.client.Localizable}.
  *
  * <h3>Extending <code>Messages</code></h3>
- * To use <code>Messages</code>, begin by defining an interface that extends
- * it. Each interface method is referred to as a <i>message accessor</i>, and
- * its corresponding message template is loaded based on the key for that
- * method. The default key is simply the unqualified name of the method, but can
- * be specified directly with an {@code @Key} annotation or a different
- * generation method using {@code @GenerateKeys}. Additionally, if
- * plural forms are used on a given method the plural form is added as a suffix
- * to the key, such as <code>widgets[one]</code> for the singular version of
- * the <code>widgets</code> message. The resulting key is used to find
- * translated versions of the message from any supported input file, such as
- * Java properties files. For example,
  *
- * {@example com.google.gwt.examples.i18n.GameStatusMessages}
+ * To use <code>Messages</code>, begin by defining an interface that extends it. Each interface
+ * method is referred to as a <i>message accessor</i>, and its corresponding message template is
+ * loaded based on the key for that method. The default key is simply the unqualified name of the
+ * method, but can be specified directly with an {@code @Key} annotation or a different generation
+ * method using {@code @GenerateKeys}. Additionally, if plural forms are used on a given method the
+ * plural form is added as a suffix to the key, such as <code>widgets[one]</code> for the singular
+ * version of the <code>widgets</code> message. The resulting key is used to find translated
+ * versions of the message from any supported input file, such as Java properties files. For
+ * example,
  *
- * expects to find properties named <code>turnsLeft</code> and
- * <code>currentScore</code> in an associated properties file, formatted as
- * message templates taking two arguments and one argument, respectively. For
- * example, the following properties would correctly bind to the
- * <code>GameStatusMessages</code> interface:
+ * <p>{@example com.google.gwt.examples.i18n.GameStatusMessages}
  *
- * {@gwt.include com/google/gwt/examples/i18n/GameStatusMessages.properties}
+ * <p>expects to find properties named <code>turnsLeft</code> and <code>currentScore</code> in an
+ * associated properties file, formatted as message templates taking two arguments and one argument,
+ * respectively. For example, the following properties would correctly bind to the <code>
+ * GameStatusMessages</code> interface:
  *
- * <p>
- * The following example demonstrates how to use constant accessors defined in
- * the interface above:
+ * <p>{@gwt.include com/google/gwt/examples/i18n/GameStatusMessages.properties}
  *
- * {@example com.google.gwt.examples.i18n.GameStatusMessagesExample#beginNewGameRound(String)}
- * </p>
+ * <p>The following example demonstrates how to use constant accessors defined in the interface
+ * above:
  *
- * <p>The following example shows how to use annotations to store the default strings
- * in the source file itself, rather than needing a properties file (you still need
- * properties files for the translated strings):
+ * <p>{@example com.google.gwt.examples.i18n.GameStatusMessagesExample#beginNewGameRound(String)}
  *
- * {@example com.google.gwt.examples.i18n.GameStatusMessagesAnnot}
- * </p>
+ * <p>The following example shows how to use annotations to store the default strings in the source
+ * file itself, rather than needing a properties file (you still need properties files for the
+ * translated strings):
  *
- * <p>In this example, calling <code>msg.turnsLeft("John", 13)</code> would
- * return the string <code>"Turns left for player 'John': 13"</code>.
- * </p>
+ * <p>{@example com.google.gwt.examples.i18n.GameStatusMessagesAnnot}
+ *
+ * <p>In this example, calling <code>msg.turnsLeft("John", 13)</code> would return the string <code>
+ * "Turns left for player 'John': 13"</code>.
  *
  * <h3>Defining Message Accessors</h3>
+ *
  * Message accessors must be of the form
  *
  * <pre>String methodName(<i>optional-params</i>)</pre>
  *
- * and parameters may be of any type. Arguments are converted into strings at
- * runtime using Java string concatenation syntax (the '+' operator), which
- * uniformly handles primitives, <code>null</code>, and invoking
- * <code>toString()</code> to format objects.
+ * and parameters may be of any type. Arguments are converted into strings at runtime using Java
+ * string concatenation syntax (the '+' operator), which uniformly handles primitives, <code>null
+ * </code>, and invoking <code>toString()</code> to format objects.
  *
- * <p>
- * Compile-time checks are performed to ensure that the number of placeholders
- * in a message template (e.g. <code>{0}</code>) matches the number of
- * parameters supplied.
- * </p>
+ * <p>Compile-time checks are performed to ensure that the number of placeholders in a message
+ * template (e.g. <code>{0}</code>) matches the number of parameters supplied.
  *
- * <p>
- * Integral arguments may be used to select the proper plural form to use for
- * different locales. To do this, mark the particular argument with
- * {@code @PluralCount} (a plural rule may be specified with
- * {@code @PluralCount} if necessary, but you will almost never need to
- * do this). The actual plural forms for the default locale can be supplied in a
- * {@code @PluralText} annotation on the method, such as
- * <code>@PluralText({"one", "You have one widget"})</code>, or they can be
- * supplied in the properties file as {@code methodkey[one]=You have one widget}. Note
- * that non-default plural forms are not inherited between locales, because the
- * different locales may have different plural rules (especially {@code default} and
- * anything else and those which use different scripts such as {@code sr_Cyrl} and
- * {@code sr_Latn} [one of which would likely be the default], but also subtle cases
- * like {@code pt} and {@code pt_BR}).
- * </p>
+ * <p>Integral arguments may be used to select the proper plural form to use for different locales.
+ * To do this, mark the particular argument with {@code @PluralCount} (a plural rule may be
+ * specified with {@code @PluralCount} if necessary, but you will almost never need to do this). The
+ * actual plural forms for the default locale can be supplied in a {@code @PluralText} annotation on
+ * the method, such as <code>@PluralText({"one", "You have one widget"})</code>, or they can be
+ * supplied in the properties file as {@code methodkey[one]=You have one widget}. Note that
+ * non-default plural forms are not inherited between locales, because the different locales may
+ * have different plural rules (especially {@code default} and anything else and those which use
+ * different scripts such as {@code sr_Cyrl} and {@code sr_Latn} [one of which would likely be the
+ * default], but also subtle cases like {@code pt} and {@code pt_BR}).
  *
- * <p>
- * Additionally, individual arguments can be marked as optional (ie, GWT will
- * not give an error if a particular translation does not reference the
- * argument) with the {@code @Optional} annotation, and an example may be supplied to
- * the translator with the {@code @Example(String)} annotation.
- * </p>
+ * <p>Additionally, individual arguments can be marked as optional (ie, GWT will not give an error
+ * if a particular translation does not reference the argument) with the {@code @Optional}
+ * annotation, and an example may be supplied to the translator with the {@code @Example(String)}
+ * annotation.
  *
  * <h3>Complete Annotations Example</h3>
- * In addition to the default properties file, default text and additional
- * metadata may be stored in the source file itself using annotations. A
- * complete example of using annotations in this way is:
  *
+ * In addition to the default properties file, default text and additional metadata may be stored in
+ * the source file itself using annotations. A complete example of using annotations in this way is:
  * <code><pre>
  * &#64;Generate(format = "org.gwtproject.i18n.rebind.format.PropertiesFormat")
  * &#64;DefaultLocale("en_US")
@@ -134,279 +128,250 @@ import java.lang.annotation.*;
  * </pre></code>
  *
  * <h3>Binding to Properties Files</h3>
- * Interfaces extending <code>Messages</code> are bound to resource files
- * using the same algorithm as interfaces extending <code>Constants</code>.
- * See the documentation for {@link Constants} for a description of the
- * algorithm.
+ *
+ * Interfaces extending <code>Messages</code> are bound to resource files using the same algorithm
+ * as interfaces extending <code>Constants</code>. See the documentation for {@link Constants} for a
+ * description of the algorithm.
  *
  * <h3>Required Module</h3>
- * Modules that use this interface should inherit
- * <code>org.gwtproject.i18n.I18N</code>.
  *
- * {@gwt.include com/google/gwt/examples/i18n/InheritsExample.gwt.xml}
+ * Modules that use this interface should inherit <code>org.gwtproject.i18n.I18N</code>.
+ *
+ * <p>{@gwt.include com/google/gwt/examples/i18n/InheritsExample.gwt.xml}
  *
  * <h3>Note</h3>
- * You should not directly implement this interface or interfaces derived from
- * it since an implementation is generated automatically when message interfaces
- * are created using {@link com.google.gwt.core.client.GWT#create(Class)}.
+ *
+ * You should not directly implement this interface or interfaces derived from it since an
+ * implementation is generated automatically when message interfaces are created using {@link
+ * com.google.gwt.core.client.GWT#create(Class)}.
  */
 public interface Messages extends LocalizableResource {
 
+  /**
+   * Provides alternate forms of a message, such as are needed when plural forms are used or a
+   * placeholder has known gender. The selection of which form to use is based on the value of the
+   * arguments marked PluralCount and/or Select.
+   *
+   * <p>Example: <code><pre>
+   *   &#64;DefaultMessage("You have {0} widgets.")
+   *   &#64;AlternateMessage({"one", "You have one widget.")
+   *   String example(&#64;PluralCount int count);
+   * </pre></code>
+   *
+   * <p>If multiple {@link PluralCount} or {@link Select} parameters are supplied, the forms for
+   * each, in the order they appear in the parameter list, are supplied separated by a vertical bar
+   * ("|"). Example: <code><pre>
+   *   &#64;DefaultMessage("You have {0} messages and {1} notifications.")
+   *   &#64;AlternateMessage({
+   *       "=0|=0", "You have no messages or notifications."
+   *       "=0|one", "You have a notification."
+   *       "one|=0", "You have a message."
+   *       "one|one", "You have one message and one notification."
+   *       "other|one", "You have {0} messages and one notification."
+   *       "one|other", "You have one message and {1} notifications."
+   *   })
+   *   String messages(&#64;PluralCount int msgCount,
+   *       &#64;PluralCount int notifyCount);
+   * </pre></code> Note that the number of permutations can grow quickly, and that the default
+   * message is used when every {@link PluralCount} or {@link Select} would use the "other" value.
+   */
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.METHOD)
+  @Documented
+  public @interface AlternateMessage {
+
     /**
-     * Provides alternate forms of a message, such as are needed when plural
-     * forms are used or a placeholder has known gender. The selection of which
-     * form to use is based on the value of the arguments marked
-     * PluralCount and/or Select.
+     * An array of pairs of strings containing the strings for different forms.
      *
-     * <p>Example:
-     * <code><pre>
-     *   &#64;DefaultMessage("You have {0} widgets.")
-     *   &#64;AlternateMessage({"one", "You have one widget.")
-     *   String example(&#64;PluralCount int count);
-     * </pre></code>
-     * </p>
+     * Each pair is the name of a form followed by the string in the source
+     * locale for that form.  Each form name is the name of a plural form if
+     * {@link PluralCount} is used, or the matching value if {@link Select} is
+     * used.  An example for a locale that has "none", "one", and "other" plural
+     * forms:
      *
-     * <p>If multiple {@link PluralCount} or {@link Select} parameters are
-     * supplied, the forms for each, in the order they appear in the parameter
-     * list, are supplied separated by a vertical bar ("|").  Example:
      * <code><pre>
-     *   &#64;DefaultMessage("You have {0} messages and {1} notifications.")
-     *   &#64;AlternateMessage({
-     *       "=0|=0", "You have no messages or notifications."
-     *       "=0|one", "You have a notification."
-     *       "one|=0", "You have a message."
-     *       "one|one", "You have one message and one notification."
-     *       "other|one", "You have {0} messages and one notification."
-     *       "one|other", "You have one message and {1} notifications."
+     * &#64;DefaultMessage("{0} widgets")
+     * &#64;AlternateMessage({"none", "No widgets", "one", "One widget"})
+     * </pre>
+     *
+     * Note that the plural form "other" gets the translation specified in
+     * {@code &#64;DefaultMessage}, as does any {@code &#64;Select} value not
+     * listed.
+     *
+     * If more than one way of selecting a translation exists, they will be
+     * combined, separated with {@code |}, in the order they are supplied as
+     * arguments in the method.  For example:
+     * <code><pre>
+     *   &#64;DefaultMessage("{0} gave away their {2} widgets")
+     *   &#64;AlternateMesssage({
+     *     "MALE|other", "{0} gave away his {2} widgets",
+     *     "FEMALE|other", "{0} gave away her {2} widgets",
+     *     "MALE|one", "{0} gave away his widget",
+     *     "FEMALE|one", "{0} gave away her widget",
+     *     "other|one", "{0} gave away their widget",
      *   })
-     *   String messages(&#64;PluralCount int msgCount,
-     *       &#64;PluralCount int notifyCount);
+     *   String giveAway(String name, &#64;Select Gender gender,
+     *       &#64;PluralCount int count);
      * </pre></code>
-     *
-     * Note that the number of permutations can grow quickly, and that the default
-     * message is used when every {@link PluralCount} or {@link Select} would use
-     * the "other" value.
-     * </p>
      */
-    @Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.METHOD)
-    @Documented
-    public @interface AlternateMessage {
+    String[] value();
+  }
 
-        /**
-         * An array of pairs of strings containing the strings for different forms.
-         *
-         * Each pair is the name of a form followed by the string in the source
-         * locale for that form.  Each form name is the name of a plural form if
-         * {@link PluralCount} is used, or the matching value if {@link Select} is
-         * used.  An example for a locale that has "none", "one", and "other" plural
-         * forms:
-         *
-         * <code><pre>
-         * &#64;DefaultMessage("{0} widgets")
-         * &#64;AlternateMessage({"none", "No widgets", "one", "One widget"})
-         * </pre>
-         *
-         * Note that the plural form "other" gets the translation specified in
-         * {@code &#64;DefaultMessage}, as does any {@code &#64;Select} value not
-         * listed.
-         *
-         * If more than one way of selecting a translation exists, they will be
-         * combined, separated with {@code |}, in the order they are supplied as
-         * arguments in the method.  For example:
-         * <code><pre>
-         *   &#64;DefaultMessage("{0} gave away their {2} widgets")
-         *   &#64;AlternateMesssage({
-         *     "MALE|other", "{0} gave away his {2} widgets",
-         *     "FEMALE|other", "{0} gave away her {2} widgets",
-         *     "MALE|one", "{0} gave away his widget",
-         *     "FEMALE|one", "{0} gave away her widget",
-         *     "other|one", "{0} gave away their widget",
-         *   })
-         *   String giveAway(String name, &#64;Select Gender gender,
-         *       &#64;PluralCount int count);
-         * </pre></code>
-         */
-        String[] value();
-    }
+  /**
+   * Default text to be used if no translation is found (and also used as the source for
+   * translation). Format should be that expected by {@link java.text.MessageFormat}.
+   *
+   * <p>Example: <code><pre>
+   *   &#64;DefaultMessage("Don''t panic - you have {0} widgets left")
+   *   String example(int count)
+   * </pre></code>
+   */
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.METHOD)
+  @Documented
+  public @interface DefaultMessage {
+    String value();
+  }
+
+  /**
+   * An example of the annotated parameter to assist translators.
+   *
+   * <p>Example: <code><pre>
+   *   String example(&#64;Example("/etc/passwd") String fileName)
+   * </pre></code>
+   */
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.PARAMETER)
+  public @interface Example {
+    String value();
+  }
+
+  /**
+   * Ignored except on parameters also tagged with {@link PluralCount}, and provides an offset to be
+   * subtracted from the value before a plural rule is chosen or the value is formatted. Note that
+   * "=n" forms are evaluated before this offset is applied.
+   *
+   * <p>Example: <code><pre>
+   *   &#64;PluralText({"=0", "No one has recommended this movie",
+   *     "=1", "{0} has recommended this movie",
+   *     "=2", "{0} and {1} have recommended this movie",
+   *     "one", "{0}, {1} and one other have recommended this movie"})
+   *   &#64;DefaultMessage("{0}, {1} and {2,number} others have recommended this movie")
+   *   String recommenders(&#64;Optional String rec1, &#64;Optional String rec2,
+   *     &#64;PluralCount &#64;Offset(2) int count);
+   * </pre></code> would result in <code><pre>
+   * recommenders("John", null, 1) => "John has..."
+   * recommenders("John", "Jane", 3) => "John, Jane, and one other..."
+   * recommenders("John", "Jane", 1402) => "John, Jane, and 1,400 others..."
+   * </pre></code>
+   */
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.PARAMETER)
+  public @interface Offset {
+    int value();
+  }
+
+  /**
+   * Indicates the specified parameter is optional and need not appear in a particular translation
+   * of this message.
+   *
+   * <p>Example: <code><pre>
+   *   String example(&#64;Optional int count)
+   * </pre></code>
+   */
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.PARAMETER)
+  public @interface Optional {}
+
+  /**
+   * Provides multiple plural forms based on a count. The selection of which plural form is
+   * performed by a PluralRule implementation.
+   *
+   * <p>This annotation is applied to a single parameter of a Messages subinterface and indicates
+   * that parameter is to be used to choose the proper plural form of the message. The parameter
+   * chosen must be of type short or int.
+   *
+   * <p>Optionally, a class literal referring to a PluralRule implementation can be supplied as the
+   * argument if the standard implementation is insufficient.
+   *
+   * <p>Example: <code><pre>
+   *   &#64;DefaultMessage("You have {0} widgets.")
+   *   &#64;AlternateMessage({"one", "You have one widget."})
+   *   String example(&#64;PluralCount int count)
+   * </pre></code>
+   */
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.PARAMETER)
+  public @interface PluralCount {
 
     /**
-     * Default text to be used if no translation is found (and also used as the
-     * source for translation). Format should be that expected by
-     * {@link java.text.MessageFormat}.
+     * The PluralRule implementation to use for this message. If not specified, the GWT-supplied one
+     * is used instead, which should cover most use cases.
      *
-     * <p>Example:
-     * <code><pre>
-     *   &#64;DefaultMessage("Don''t panic - you have {0} widgets left")
-     *   String example(int count)
-     * </pre></code>
-     * </p>
+     * <p>{@code PluralRule.class} is used as a default value here, which will be replaced during
+     * code generation with the default implementation.
      */
-    @Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.METHOD)
-    @Documented
-    public @interface DefaultMessage {
-        String value();
-    }
+    // http://bugs.sun.com/view_bug.do?bug_id=6512707
+    Class<? extends PluralRule> value() default org.gwtproject.i18n.client.PluralRule.class;
+  }
+
+  /**
+   * Provides multiple plural forms based on a count. The selection of which plural form to use is
+   * based on the value of the argument marked PluralCount, which may also specify an alternate
+   * plural rule to use.
+   *
+   * <p>Example: <code><pre>
+   *   &#64;DefaultMessage("You have {0} widgets.")
+   *   &#64;PluralText({"one", "You have one widget.")
+   *   String example(&#64;PluralCount int count)
+   * </pre></code>
+   *
+   * @deprecated use {@link AlternateMessage} instead
+   */
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.METHOD)
+  @Documented
+  @Deprecated
+  public @interface PluralText {
 
     /**
-     * An example of the annotated parameter to assist translators.
+     * An array of pairs of strings containing the strings for different plural
+     * forms.
      *
-     * <p>Example:
+     * Each pair is the name of the plural form (as returned by
+     * PluralForm.toString) followed by the string for that plural form. An
+     * example for a locale that has "none", "one", and "other" plural forms:
+     *
      * <code><pre>
-     *   String example(&#64;Example("/etc/passwd") String fileName)
-     * </pre></code>
-     * </p>
+     * &#64;DefaultMessage("{0} widgets")
+     * &#64;PluralText({"none", "No widgets", "one", "One widget"})
+     * </pre>
+     *
+     * "other" must not be included in this array as it will map to the
+     * DefaultMessage value.
      */
-    @Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.PARAMETER)
-    public @interface Example {
-        String value();
-    }
+    String[] value();
+  }
 
-    /**
-     * Ignored except on parameters also tagged with {@link PluralCount}, and
-     * provides an offset to be subtracted from the value before a plural rule
-     * is chosen or the value is formatted.  Note that "=n" forms are evaluated
-     * before this offset is applied.
-     *
-     * <p>Example:
-     * <code><pre>
-     *   &#64;PluralText({"=0", "No one has recommended this movie",
-     *     "=1", "{0} has recommended this movie",
-     *     "=2", "{0} and {1} have recommended this movie",
-     *     "one", "{0}, {1} and one other have recommended this movie"})
-     *   &#64;DefaultMessage("{0}, {1} and {2,number} others have recommended this movie")
-     *   String recommenders(&#64;Optional String rec1, &#64;Optional String rec2,
-     *     &#64;PluralCount &#64;Offset(2) int count);
-     * </pre></code>
-     * would result in
-     * <code><pre>
-     * recommenders("John", null, 1) => "John has..."
-     * recommenders("John", "Jane", 3) => "John, Jane, and one other..."
-     * recommenders("John", "Jane", 1402) => "John, Jane, and 1,400 others..."
-     * </pre></code>
-     * </p>
-     */
-    @Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.PARAMETER)
-    public @interface Offset {
-        int value();
-    }
-
-    /**
-     * Indicates the specified parameter is optional and need not appear in a
-     * particular translation of this message.
-     *
-     * <p>Example:
-     * <code><pre>
-     *   String example(&#64;Optional int count)
-     * </pre></code>
-     * </p>
-     */
-    @Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.PARAMETER)
-    public @interface Optional {
-    }
-
-    /**
-     * Provides multiple plural forms based on a count. The selection of which
-     * plural form is performed by a PluralRule implementation.
-     *
-     * This annotation is applied to a single parameter of a Messages subinterface
-     * and indicates that parameter is to be used to choose the proper plural form
-     * of the message. The parameter chosen must be of type short or int.
-     *
-     * Optionally, a class literal referring to a PluralRule implementation can be
-     * supplied as the argument if the standard implementation is insufficient.
-     *
-     * <p>Example:
-     * <code><pre>
-     *   &#64;DefaultMessage("You have {0} widgets.")
-     *   &#64;AlternateMessage({"one", "You have one widget."})
-     *   String example(&#64;PluralCount int count)
-     * </pre></code>
-     * </p>
-     */
-    @Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.PARAMETER)
-    public @interface PluralCount {
-
-        /**
-         * The PluralRule implementation to use for this message. If not specified,
-         * the GWT-supplied one is used instead, which should cover most use cases.
-         *
-         * <p>{@code PluralRule.class} is used as a default value here, which will
-         * be replaced during code generation with the default implementation.
-         * </p>
-         */
-        // http://bugs.sun.com/view_bug.do?bug_id=6512707
-        Class<? extends PluralRule> value() default org.gwtproject.i18n.client.PluralRule.class;
-    }
-
-    /**
-     * Provides multiple plural forms based on a count. The selection of which
-     * plural form to use is based on the value of the argument marked
-     * PluralCount, which may also specify an alternate plural rule to use.
-     *
-     * <p>Example:
-     * <code><pre>
-     *   &#64;DefaultMessage("You have {0} widgets.")
-     *   &#64;PluralText({"one", "You have one widget.")
-     *   String example(&#64;PluralCount int count)
-     * </pre></code>
-     * </p>
-     *
-     * @deprecated use {@link AlternateMessage} instead
-     */
-    @Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.METHOD)
-    @Documented
-    @Deprecated
-    public @interface PluralText {
-
-        /**
-         * An array of pairs of strings containing the strings for different plural
-         * forms.
-         *
-         * Each pair is the name of the plural form (as returned by
-         * PluralForm.toString) followed by the string for that plural form. An
-         * example for a locale that has "none", "one", and "other" plural forms:
-         *
-         * <code><pre>
-         * &#64;DefaultMessage("{0} widgets")
-         * &#64;PluralText({"none", "No widgets", "one", "One widget"})
-         * </pre>
-         *
-         * "other" must not be included in this array as it will map to the
-         * DefaultMessage value.
-         */
-        String[] value();
-    }
-
-    /**
-     * Provides multiple forms based on a dynamic parameter.
-     *
-     * This annotation is applied to a single parameter of a Messages subinterface
-     * and indicates that parameter is to be used to choose the proper form of the
-     * message. The parameter chosen must be of type Enum, String, boolean, or a
-     * primitive integral type.  This is frequently used to get proper gender for
-     * translations to languages where surrounding words depend on the gender of
-     * a person or noun.  This also marks the parameter as {@link Optional}.
-     *
-     * <p>Example:
-     * <code><pre>
-     *   &#64;DefaultMessage("{0} likes their widgets.")
-     *   &#64;AlternateMessage({
-     *       "FEMALE", "{0} likes her widgets.",
-     *       "MALE", "{0} likes his widgets.",
-     *   })
-     *   String example(String name, &#64;Select Gender gender)
-     * </pre></code>
-     * </p>
-     */
-    @Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.PARAMETER)
-    public @interface Select {
-    }
+  /**
+   * Provides multiple forms based on a dynamic parameter.
+   *
+   * <p>This annotation is applied to a single parameter of a Messages subinterface and indicates
+   * that parameter is to be used to choose the proper form of the message. The parameter chosen
+   * must be of type Enum, String, boolean, or a primitive integral type. This is frequently used to
+   * get proper gender for translations to languages where surrounding words depend on the gender of
+   * a person or noun. This also marks the parameter as {@link Optional}.
+   *
+   * <p>Example: <code><pre>
+   *   &#64;DefaultMessage("{0} likes their widgets.")
+   *   &#64;AlternateMessage({
+   *       "FEMALE", "{0} likes her widgets.",
+   *       "MALE", "{0} likes his widgets.",
+   *   })
+   *   String example(String name, &#64;Select Gender gender)
+   * </pre></code>
+   */
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.PARAMETER)
+  public @interface Select {}
 }

--- a/gwt-i18n/src/main/java/org/gwtproject/i18n/client/PluralRule.java
+++ b/gwt-i18n/src/main/java/org/gwtproject/i18n/client/PluralRule.java
@@ -1,90 +1,93 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.gwtproject.i18n.client;
 
 /**
- * The interface that plural rules must implement.  Implementations of
- * this interface will be used both at compile time (pluralForms) and
- * at run time (select), so implementations must be both translatable
- * and not reference JSNI methods.
+ * The interface that plural rules must implement. Implementations of this interface will be used
+ * both at compile time (pluralForms) and at run time (select), so implementations must be both
+ * translatable and not reference JSNI methods.
  */
 public interface PluralRule {
 
+  /**
+   * Information about the plural forms supported by this rule which will be used during code
+   * generation and by tools to provide information to translators.
+   */
+  public static class PluralForm {
+    private final String name;
+    private final String description;
+    private final boolean noWarn;
+
     /**
-     * Information about the plural forms supported by this rule which
-     * will be used during code generation and by tools to provide
-     * information to translators.
+     * Create the plural form.
+     *
+     * @param name
+     * @param description
      */
-    public static class PluralForm {
-        private final String name;
-        private final String description;
-        private final boolean noWarn;
-
-        /**
-         * Create the plural form.
-         *
-         * @param name
-         * @param description
-         */
-        public PluralForm(String name, String description) {
-            this(name, description, false);
-        }
-
-        /**
-         * Create the plural form.
-         *
-         * @param name
-         * @param description
-         * @param noWarn if true, do not warn if this form is missing from a
-         *     translation.  This is used for those cases where a plural form
-         *     is defined for a language, but is very rarely used.
-         */
-        public PluralForm(String name, String description, boolean noWarn) {
-            this.name = name;
-            this.description = description;
-            this.noWarn = noWarn;
-        }
-
-        /**
-         * Returns the description.
-         */
-        public String getDescription() {
-            return description;
-        }
-
-        /**
-         * Returns the name.
-         */
-        public String getName() {
-            return name;
-        }
-
-        /**
-         * Returns true if the generator should warn if this plural form is not
-         * present.
-         */
-        public boolean getWarnIfMissing() {
-            return !noWarn;
-        }
+    public PluralForm(String name, String description) {
+      this(name, description, false);
     }
 
     /**
-     * Returns the list of values which are valid for this rule.  The
-     * default or "other" plural form must be first in the list with
-     * an index of 0 -- this form will be used if no other form applies
-     * and is also mapped to the default text for a given message.
+     * Create the plural form.
      *
-     * This method will be executed at compile time and may not contain
-     * any references, even indirectly, to JSNI methods.
+     * @param name
+     * @param description
+     * @param noWarn if true, do not warn if this form is missing from a translation. This is used
+     *     for those cases where a plural form is defined for a language, but is very rarely used.
      */
-    PluralForm[] pluralForms();
+    public PluralForm(String name, String description, boolean noWarn) {
+      this.name = name;
+      this.description = description;
+      this.noWarn = noWarn;
+    }
 
-    /**
-     * Returns the plural form appropriate for this count.
-     *
-     * This method will be executed at runtime, so must be translatable.
-     *
-     * @param n count of items to choose plural form for
-     * @return the plural form to use (must be a valid index
-     *     into the array returned by pluralForms).
-     */
-    int select(int n);
+    /** Returns the description. */
+    public String getDescription() {
+      return description;
+    }
+
+    /** Returns the name. */
+    public String getName() {
+      return name;
+    }
+
+    /** Returns true if the generator should warn if this plural form is not present. */
+    public boolean getWarnIfMissing() {
+      return !noWarn;
+    }
+  }
+
+  /**
+   * Returns the list of values which are valid for this rule. The default or "other" plural form
+   * must be first in the list with an index of 0 -- this form will be used if no other form applies
+   * and is also mapped to the default text for a given message.
+   *
+   * <p>This method will be executed at compile time and may not contain any references, even
+   * indirectly, to JSNI methods.
+   */
+  PluralForm[] pluralForms();
+
+  /**
+   * Returns the plural form appropriate for this count.
+   *
+   * <p>This method will be executed at runtime, so must be translatable.
+   *
+   * @param n count of items to choose plural form for
+   * @return the plural form to use (must be a valid index into the array returned by pluralForms).
+   */
+  int select(int n);
 }

--- a/gwt-i18n/src/main/java/org/gwtproject/i18n/shared/GwtLocale.java
+++ b/gwt-i18n/src/main/java/org/gwtproject/i18n/shared/GwtLocale.java
@@ -20,38 +20,34 @@ import java.util.List;
 /**
  * Class representing GWT locales and conversion to/from other formats.
  *
- * These locales correspond to BCP47.
+ * <p>These locales correspond to BCP47.
  */
 public interface GwtLocale extends Comparable<GwtLocale> {
 
   String DEFAULT_LOCALE = "default";
 
-  /**
-   * The default comparison is a lexical ordering.
-   */
+  /** The default comparison is a lexical ordering. */
   int compareTo(GwtLocale o);
 
   /**
-   * Returns the list of aliases for this locale.  The canonical form of the
-   * current locale is always first on the list.
+   * Returns the list of aliases for this locale. The canonical form of the current locale is always
+   * first on the list.
    *
-   * Language/region codes have changed over time, so some systems continue to
-   * use the older codes.  Aliases allow GWT to use the official Unicode CLDR
-   * locales while still interoperating with such systems.
+   * <p>Language/region codes have changed over time, so some systems continue to use the older
+   * codes. Aliases allow GWT to use the official Unicode CLDR locales while still interoperating
+   * with such systems.
    *
    * @return alias list
    */
   List<GwtLocale> getAliases();
 
   /**
-   * Returns the locale as a fixed-format string suitable for use in searching
-   * for localized resources.  The format is language_Script_REGION_VARIANT,
-   * where language is a 2-8 letter code (possibly with 3-letter extensions),
-   * script is a 4-letter code with an initial capital letter, region is a
-   * 2-character country code or a 3-digit region code, and variant is a 5-8
-   * character (may be 4 if the first character is numeric) code.  If a
-   * component is missing, its preceding _ is also omitted.  If this is the
-   * default locale, the empty string will be returned.
+   * Returns the locale as a fixed-format string suitable for use in searching for localized
+   * resources. The format is language_Script_REGION_VARIANT, where language is a 2-8 letter code
+   * (possibly with 3-letter extensions), script is a 4-letter code with an initial capital letter,
+   * region is a 2-character country code or a 3-digit region code, and variant is a 5-8 character
+   * (may be 4 if the first character is numeric) code. If a component is missing, its preceding _
+   * is also omitted. If this is the default locale, the empty string will be returned.
    *
    * @return String representing locale
    */
@@ -59,12 +55,12 @@ public interface GwtLocale extends Comparable<GwtLocale> {
 
   /**
    * Returns this locale in canonical form.
+   *
    * <ul>
-   *  <li>Deprecated language/region tags are replaced with official versions
-   *  <li>Default scripts are removed (including region-specific defaults for
-   *      Chinese)
-   *  <li>no/nb/nn are normalized
-   *  <li>Default region for zh_Hans and zh_Hant if none specified
+   *   <li>Deprecated language/region tags are replaced with official versions
+   *   <li>Default scripts are removed (including region-specific defaults for Chinese)
+   *   <li>no/nb/nn are normalized
+   *   <li>Default region for zh_Hans and zh_Hant if none specified
    * </ul>
    *
    * @return GwtLocale instance
@@ -72,81 +68,61 @@ public interface GwtLocale extends Comparable<GwtLocale> {
   GwtLocale getCanonicalForm();
 
   /**
-   * Returns the complete list of locales to search for the current locale.
-   * This list will always start with the canonical form of this locale, and
-   * end with "default", and include all appropriate aliases along the way.
+   * Returns the complete list of locales to search for the current locale. This list will always
+   * start with the canonical form of this locale, and end with "default", and include all
+   * appropriate aliases along the way.
    *
    * @return search list
    */
   List<GwtLocale> getCompleteSearchList();
 
   /**
-   * Returns a list of locales to search for, in order of preference.  The
-   * current locale is always first on the list.  Aliases are not included
-   * in the list -- use {@link #getAliases} to expand those.
+   * Returns a list of locales to search for, in order of preference. The current locale is always
+   * first on the list. Aliases are not included in the list -- use {@link #getAliases} to expand
+   * those.
    *
    * @return inheritance list
    */
   List<GwtLocale> getInheritanceChain();
 
-  /**
-   * Returns the language portion of the locale, or null if none.
-   */
+  /** Returns the language portion of the locale, or null if none. */
   String getLanguage();
 
-  /**
-   * Returns the language portion of the locale, or the empty string if none.
-   */
+  /** Returns the language portion of the locale, or the empty string if none. */
   String getLanguageNotNull();
 
-  /**
-   * Returns the region portion of the locale, or null if none.
-   */
+  /** Returns the region portion of the locale, or null if none. */
   String getRegion();
 
-  /**
-   * Returns the region portion of the locale, or the empty string if none.
-   */
+  /** Returns the region portion of the locale, or the empty string if none. */
   String getRegionNotNull();
 
-  /**
-   * Returns the script portion of the locale, or null if none.
-   */
+  /** Returns the script portion of the locale, or null if none. */
   String getScript();
 
-  /**
-   * Returns the script portion of the locale, or the empty string if none.
-   */
+  /** Returns the script portion of the locale, or the empty string if none. */
   String getScriptNotNull();
 
-  /**
-   * Returns the variant portion of the locale, or null if none.
-   */
+  /** Returns the variant portion of the locale, or null if none. */
   String getVariant();
 
-  /**
-   * Returns the variant portion of the locale, or the empty string if none.
-   */
+  /** Returns the variant portion of the locale, or the empty string if none. */
   String getVariantNotNull();
 
   /**
-   * Returns true if this locale inherits from the specified locale.  Note that
-   * locale.inheritsFrom(locale) is false -- if you want that to be true, you
-   * should just use locale.getInheritanceChain().contains(x).
+   * Returns true if this locale inherits from the specified locale. Note that
+   * locale.inheritsFrom(locale) is false -- if you want that to be true, you should just use
+   * locale.getInheritanceChain().contains(x).
    *
    * @param parent locale to test against
    * @return true if parent is an ancestor of this locale
    */
   boolean inheritsFrom(GwtLocale parent);
 
-  /**
-   * Returns true if this is the default or root locale.
-   */
+  /** Returns true if this is the default or root locale. */
   boolean isDefault();
 
-  /**
-   * Returns a human readable string -- "default" or the same as getAsString().
-   */
+  /** Returns a human readable string -- "default" or the same as getAsString(). */
   String toString();
 
   /**

--- a/gwt-i18n/src/main/java/org/gwtproject/i18n/shared/GwtLocaleFactory.java
+++ b/gwt-i18n/src/main/java/org/gwtproject/i18n/shared/GwtLocaleFactory.java
@@ -15,15 +15,13 @@
  */
 package org.gwtproject.i18n.shared;
 
-/**
- * Factories that know how to create GwtLocale instances.
- */
+/** Factories that know how to create GwtLocale instances. */
 public interface GwtLocaleFactory {
 
   /**
    * Construct a GWT locale from its component parts.
    *
-   * Null or empty strings are accepted for parts not present.
+   * <p>Null or empty strings are accepted for parts not present.
    *
    * @param language
    * @param script
@@ -31,26 +29,22 @@ public interface GwtLocaleFactory {
    * @param variant
    * @return GwtLocale instance, unique for a given set of values
    */
-  GwtLocale fromComponents(String language, String script, String region,
-                           String variant);
+  GwtLocale fromComponents(String language, String script, String region, String variant);
 
   /**
-   * Get a GWT locale from a string conforming to a subset of BCP47
-   * (specifically assuming extension tags are not present, at most
-   * one variant is present, and grandfathered tags are not supported;
-   * also private-use tags are only supported for the entire tag).
-   * Only minimal validation of BCP47 tags is performed, and will continue
-   * with what it is able to parse if unexpected input is encountered.
+   * Get a GWT locale from a string conforming to a subset of BCP47 (specifically assuming extension
+   * tags are not present, at most one variant is present, and grandfathered tags are not supported;
+   * also private-use tags are only supported for the entire tag). Only minimal validation of BCP47
+   * tags is performed, and will continue with what it is able to parse if unexpected input is
+   * encountered.
    *
-   * A null or empty string is treated as the default locale.
+   * <p>A null or empty string is treated as the default locale.
    *
    * @param localeName
    * @return a locale instance, always the same one for a given localeName
    */
   GwtLocale fromString(String localeName);
 
-  /**
-   * Returns an instance of the default locale.
-   */
+  /** Returns an instance of the default locale. */
   GwtLocale getDefault();
 }

--- a/gwt-i18n/src/main/java/org/gwtproject/i18n/shared/Localizable.java
+++ b/gwt-i18n/src/main/java/org/gwtproject/i18n/shared/Localizable.java
@@ -18,24 +18,21 @@ package org.gwtproject.i18n.shared;
 import java.lang.annotation.*;
 
 /**
- * A tag interface that serves as the root of a family of types used in static
- * internationalization. Using <code>GWT.create(<i>class</i>)</code> to
- * instantiate a type that directly extends or implements
- * <code>Localizable</code> invites locale-sensitive type substitution.
+ * A tag interface that serves as the root of a family of types used in static internationalization.
+ * Using <code>GWT.create(<i>class</i>)</code> to instantiate a type that directly extends or
+ * implements <code>Localizable</code> invites locale-sensitive type substitution.
  *
  * <h3>Locale-sensitive Type Substitution</h3>
- * If a type <code>Type</code> directly extends or implements
- * <code>Localizable</code> (as opposed to
- * {@link org.gwtproject.i18n.client.Constants} or
- * {@link org.gwtproject.i18n.client.Messages}) and the following code is used
- * to create an object from <code>Type</code> as follows:
+ *
+ * If a type <code>Type</code> directly extends or implements <code>Localizable</code> (as opposed
+ * to {@link org.gwtproject.i18n.client.Constants} or {@link org.gwtproject.i18n.client.Messages})
+ * and the following code is used to create an object from <code>Type</code> as follows:
  *
  * <pre class="code">Type localized = (Type)GWT.create(Type.class);</pre>
  *
- * then <code>localized</code> will be assigned an instance of a localized
- * subclass, selected based on the value of the <code>locale</code> client
- * property. The choice of subclass is determined by the following naming
- * pattern:
+ * then <code>localized</code> will be assigned an instance of a localized subclass, selected based
+ * on the value of the <code>locale</code> client property. The choice of subclass is determined by
+ * the following naming pattern:
  *
  * <table>
  *
@@ -65,37 +62,32 @@ import java.lang.annotation.*;
  * </table>
  *
  * where in the table above <code>x</code> is a <a
- * href="http://ftp.ics.uci.edu/pub/ietf/http/related/iso639.txt">ISO language
- * code</a> and <code>Y</code> is a two-letter <a
- * href="http://userpage.chemie.fu-berlin.de/diverse/doc/ISO_3166.html">ISO
- * country code</a>.
+ * href="http://ftp.ics.uci.edu/pub/ietf/http/related/iso639.txt">ISO language code</a> and <code>Y
+ * </code> is a two-letter <a
+ * href="http://userpage.chemie.fu-berlin.de/diverse/doc/ISO_3166.html">ISO country code</a>.
  *
  * <h3>Specifying Locale</h3>
- * The locale of a module is specified using the <code>locale</code> client
- * property, which can be specified using either a meta tag or as part of the
- * query string in the host page's URL. If both are specified, the query string
- * takes precedence.
  *
- * <p>
- * To specify the <code>locale</code> client property using a meta tag in the
- * host HTML, use <code>gwt:property</code> as follows:
+ * The locale of a module is specified using the <code>locale</code> client property, which can be
+ * specified using either a meta tag or as part of the query string in the host page's URL. If both
+ * are specified, the query string takes precedence.
+ *
+ * <p>To specify the <code>locale</code> client property using a meta tag in the host HTML, use
+ * <code>gwt:property</code> as follows:
  *
  * <pre>&lt;meta name="gwt:property" content="locale.new=x_Y"&gt;</pre>
  *
  * For example, the following host HTML page sets the locale to "ja_JP":
  *
- * {@gwt.include com/google/gwt/examples/i18n/ColorNameLookupExample_ja_JP.html}
- * </p>
+ * <p>{@gwt.include com/google/gwt/examples/i18n/ColorNameLookupExample_ja_JP.html}
  *
- * <p>
- * To specify the <code>locale</code> client property using a query string,
- * specify a value for the name <code>locale</code>. For example,
+ * <p>To specify the <code>locale</code> client property using a query string, specify a value for
+ * the name <code>locale</code>. For example,
  *
  * <pre>http://www.example.org/myapp.html?locale=fr_CA</pre>
  *
- * </p>
- *
  * <h3>For More Information</h3>
+ *
  * See the GWT Developer Guide for an introduction to internationalization.
  *
  * @see org.gwtproject.i18n.client.Constants
@@ -103,17 +95,17 @@ import java.lang.annotation.*;
  * @see org.gwtproject.i18n.client.Messages
  * @see org.gwtproject.i18n.client.Dictionary
  */
-@Localizable.I18nLocaleSuffuxes({"default", "en", "es", "fr", "de"})//TODO real list
+@Localizable.I18nLocaleSuffuxes({"default", "en", "es", "fr", "de"}) // TODO real list
 public interface Localizable {
-    @Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.TYPE)
-    @Documented
-    @interface IsLocalizable {}
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.TYPE)
+  @Documented
+  @interface IsLocalizable {}
 
-    @Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.TYPE)
-    @Documented
-    @interface I18nLocaleSuffuxes {
-        String[] value();
-    }
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.TYPE)
+  @Documented
+  @interface I18nLocaleSuffuxes {
+    String[] value();
+  }
 }

--- a/gwt-i18n/src/main/java/org/gwtproject/i18n/shared/SupportedLocales.java
+++ b/gwt-i18n/src/main/java/org/gwtproject/i18n/shared/SupportedLocales.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.gwtproject.i18n.shared;
 
 import java.lang.annotation.Documented;
@@ -7,5 +22,5 @@ import java.lang.annotation.Target;
 @Documented
 @Target(ElementType.TYPE)
 public @interface SupportedLocales {
-    String[] value() default {};
+  String[] value() default {};
 }

--- a/gwt-localizable-processor/src/main/java/org/gwtproject/i18n/processor/LocalizableProcessingStep.java
+++ b/gwt-localizable-processor/src/main/java/org/gwtproject/i18n/processor/LocalizableProcessingStep.java
@@ -1,151 +1,183 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.gwtproject.i18n.processor;
 
 import com.google.auto.common.BasicAnnotationProcessor;
 import com.google.auto.common.MoreElements;
 import com.google.common.collect.SetMultimap;
 import com.squareup.javapoet.*;
-import org.gwtproject.i18n.shared.Localizable;
-
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.util.*;
+import java.util.stream.Collectors;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeKind;
-import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.Types;
-import javax.tools.Diagnostic;
-import java.io.IOException;
-import java.lang.annotation.Annotation;
-import java.util.*;
-import java.util.stream.Collectors;
+import org.gwtproject.i18n.shared.Localizable;
 
 public class LocalizableProcessingStep implements BasicAnnotationProcessor.ProcessingStep {
-    private final ProcessingEnvironment processingEnv;
+  private final ProcessingEnvironment processingEnv;
 
-    public LocalizableProcessingStep(ProcessingEnvironment processingEnv) {
-        this.processingEnv = processingEnv;
+  public LocalizableProcessingStep(ProcessingEnvironment processingEnv) {
+    this.processingEnv = processingEnv;
+  }
+
+  @Override
+  public Set<? extends Class<? extends Annotation>> annotations() {
+    return Collections.singleton(Localizable.IsLocalizable.class);
+  }
+
+  @Override
+  public Set<Element> process(
+      SetMultimap<Class<? extends Annotation>, Element> elementsByAnnotation) {
+
+    for (Element element : elementsByAnnotation.get(Localizable.IsLocalizable.class)) {
+      // build a model
+      String packageName =
+          processingEnv.getElementUtils().getPackageOf(element).getQualifiedName().toString();
+
+      // collect the possible locales
+      // TODO correctly sort this based on the logic ahmad has worked up
+
+      List<String> locales = getLocaleNames(element);
+      // TODO remove hack which restricts us to default
+      locales = Collections.singletonList("default");
+
+      // implement the interface into a new type for each locale key
+      Map<String, ClassName> keyToNameMapping = new HashMap<>();
+
+      keyToNameMapping.put(
+          "default", ClassName.get(packageName, element.getSimpleName().toString() + "_default"));
+
+      TypeSpec.Builder defaultImplBuilder =
+          TypeSpec.classBuilder(element.getSimpleName().toString() + "_default")
+              .addModifiers(Modifier.PUBLIC)
+              .addSuperinterface(ClassName.get(element.asType()));
+
+      MoreElements.getLocalAndInheritedMethods(
+              (TypeElement) element, processingEnv.getTypeUtils(), processingEnv.getElementUtils())
+          .stream()
+          //                    .filter(method -> !method.getModifiers().contains(Modifier.STATIC))
+          .filter(method -> !method.getModifiers().contains(Modifier.DEFAULT))
+
+          // skip anything on Object
+          .filter(
+              method ->
+                  !Object.class
+                      .getName()
+                      .equals(ClassName.get(method.getEnclosingElement().asType()).toString()))
+          .forEach(
+              method -> {
+                MethodSpec.Builder impl =
+                    MethodSpec.methodBuilder(method.getSimpleName().toString())
+                        .addModifiers(Modifier.PUBLIC)
+                        .returns(TypeName.get(method.getReturnType()))
+                        .addAnnotation(Override.class);
+                for (VariableElement parameter : method.getParameters()) {
+                  impl.addParameter(
+                      TypeName.get(parameter.asType()), parameter.getSimpleName().toString());
+                }
+                // TODO support other return types, return correct values, etc
+                if (method.getReturnType().getKind().isPrimitive()) {
+                  if (method.getReturnType().getKind() == TypeKind.BOOLEAN) {
+                    impl.addStatement("return false");
+                  } else {
+                    impl.addStatement("return ($T)0", TypeName.get(method.getReturnType()));
+                  }
+                } else {
+
+                  impl.addStatement("return $S", method.getSimpleName().toString());
+                }
+
+                defaultImplBuilder.addMethod(impl.build());
+              });
+
+      try {
+        JavaFile.builder(packageName, defaultImplBuilder.build())
+            .build()
+            .writeTo(processingEnv.getFiler());
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+
+      // for each method that needs overriding, generate a method which
+      // either reads from the default annotation or just returns the
+      // method name itself, ignoring all args
+
+      // based on the types created and their locale,
+      // create a factor
+      TypeSpec factory =
+          TypeSpec.classBuilder(element.getSimpleName() + "_Factory")
+              .addMethod(
+                  MethodSpec.methodBuilder("create")
+                      .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                      .returns(ClassName.get(element.asType()))
+                      .addStatement("return create(System.getProperty(\"locale\", \"default\"))")
+                      .build())
+              .addMethod(
+                  MethodSpec.methodBuilder("create")
+                      .addParameter(String.class, "locale")
+                      .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                      .returns(ClassName.get(element.asType()))
+                      .addCode(makeSwitchCase(locales, keyToNameMapping))
+                      .build())
+              .build();
+      try {
+        JavaFile.builder(packageName, factory).build().writeTo(processingEnv.getFiler());
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
     }
 
-    @Override
-    public Set<? extends Class<? extends Annotation>> annotations() {
-        return Collections.singleton(Localizable.IsLocalizable.class);
+    return Collections.emptySet();
+  }
+
+  private List<String> getLocaleNames(Element element) {
+    // breadth-first search to find the annotation since you can have diamond inheritance in
+    // interfaces
+    List<Element> typesToCheck = new ArrayList<>();
+    typesToCheck.add(element);
+    for (int i = 0; i < typesToCheck.size(); i++) {
+      Element check = typesToCheck.get(i);
+      Localizable.I18nLocaleSuffuxes annotation =
+          check.getAnnotation(Localizable.I18nLocaleSuffuxes.class);
+      if (annotation != null) {
+        return Arrays.asList(annotation.value());
+      }
+      TypeElement type = (TypeElement) check;
+      typesToCheck.addAll(
+          type.getInterfaces()
+              .stream()
+              .map(m -> processingEnv.getTypeUtils().asElement(m))
+              .collect(Collectors.toList()));
     }
+    return Collections.emptyList();
+  }
 
-    @Override
-    public Set<Element> process(SetMultimap<Class<? extends Annotation>, Element> elementsByAnnotation) {
-
-        for (Element element : elementsByAnnotation.get(Localizable.IsLocalizable.class)) {
-            // build a model
-            String packageName = processingEnv.getElementUtils().getPackageOf(element).getQualifiedName().toString();
-
-            // collect the possible locales
-            //TODO correctly sort this based on the logic ahmad has worked up
-
-            List<String> locales = getLocaleNames(element);
-            // TODO remove hack which restricts us to default
-            locales = Collections.singletonList("default");
-
-
-            // implement the interface into a new type for each locale key
-            Map<String, ClassName> keyToNameMapping = new HashMap<>();
-
-
-            keyToNameMapping.put("default", ClassName.get(packageName, element.getSimpleName().toString() + "_default"));
-
-            TypeSpec.Builder defaultImplBuilder = TypeSpec.classBuilder(element.getSimpleName().toString() + "_default")
-                    .addModifiers(Modifier.PUBLIC)
-                    .addSuperinterface(ClassName.get(element.asType()));
-
-            MoreElements.getLocalAndInheritedMethods((TypeElement) element, processingEnv.getTypeUtils(), processingEnv.getElementUtils())
-                    .stream()
-//                    .filter(method -> !method.getModifiers().contains(Modifier.STATIC))
-                    .filter(method -> !method.getModifiers().contains(Modifier.DEFAULT))
-
-                    // skip anything on Object
-                    .filter(method -> !Object.class.getName().equals(ClassName.get(method.getEnclosingElement().asType()).toString()))
-                    .forEach(method -> {
-                        MethodSpec.Builder impl = MethodSpec.methodBuilder(method.getSimpleName().toString())
-                                .addModifiers(Modifier.PUBLIC)
-                                .returns(TypeName.get(method.getReturnType()))
-                                .addAnnotation(Override.class);
-                        for (VariableElement parameter : method.getParameters()) {
-                            impl.addParameter(TypeName.get(parameter.asType()), parameter.getSimpleName().toString());
-                        }
-                        //TODO support other return types, return correct values, etc
-                        if (method.getReturnType().getKind().isPrimitive()) {
-                            if (method.getReturnType().getKind() == TypeKind.BOOLEAN) {
-                                impl.addStatement("return false");
-                            } else {
-                                impl.addStatement("return ($T)0", TypeName.get(method.getReturnType()));
-                            }
-                        } else {
-
-                            impl.addStatement("return $S", method.getSimpleName().toString());
-                        }
-
-                        defaultImplBuilder.addMethod(impl.build());
-                    });
-
-            try {
-                JavaFile.builder(packageName, defaultImplBuilder.build()).build().writeTo(processingEnv.getFiler());
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-
-            // for each method that needs overriding, generate a method which
-            // either reads from the default annotation or just returns the
-            // method name itself, ignoring all args
-
-            // based on the types created and their locale,
-            // create a factor
-            TypeSpec factory = TypeSpec.classBuilder(element.getSimpleName() + "_Factory")
-                    .addMethod(MethodSpec.methodBuilder("create")
-                            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                            .returns(ClassName.get(element.asType()))
-                            .addStatement("return create(System.getProperty(\"locale\", \"default\"))")
-                            .build())
-                    .addMethod(MethodSpec.methodBuilder("create")
-                            .addParameter(String.class, "locale")
-                            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                            .returns(ClassName.get(element.asType()))
-                            .addCode(makeSwitchCase(locales, keyToNameMapping))
-                            .build())
-                    .build();
-            try {
-                JavaFile.builder(packageName, factory).build().writeTo(processingEnv.getFiler());
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
-
-        return Collections.emptySet();
+  private CodeBlock makeSwitchCase(List<String> locales, Map<String, ClassName> keyToNameMapping) {
+    CodeBlock.Builder switchCase = CodeBlock.builder().beginControlFlow("switch (locale)");
+    for (String locale : locales) {
+      switchCase
+          .beginControlFlow("case $S:", locale)
+          .addStatement("return new $T()", keyToNameMapping.get(locale))
+          .endControlFlow();
     }
-
-    private List<String> getLocaleNames(Element element) {
-        //breadth-first search to find the annotation since you can have diamond inheritance in interfaces
-        List<Element> typesToCheck = new ArrayList<>();
-        typesToCheck.add(element);
-        for (int i = 0; i < typesToCheck.size(); i++) {
-            Element check = typesToCheck.get(i);
-            Localizable.I18nLocaleSuffuxes annotation = check.getAnnotation(Localizable.I18nLocaleSuffuxes.class);
-            if (annotation != null) {
-                return Arrays.asList(annotation.value());
-            }
-            TypeElement type = (TypeElement) check;
-            typesToCheck.addAll(type.getInterfaces().stream().map(m -> processingEnv.getTypeUtils().asElement(m)).collect(Collectors.toList()));
-        }
-        return Collections.emptyList();
-    }
-
-    private CodeBlock makeSwitchCase(List<String> locales, Map<String, ClassName> keyToNameMapping) {
-        CodeBlock.Builder switchCase = CodeBlock.builder().beginControlFlow("switch (locale)");
-        for (String locale : locales) {
-            switchCase.beginControlFlow("case $S:", locale)
-                    .addStatement("return new $T()", keyToNameMapping.get(locale))
-                    .endControlFlow();
-        }
-        return switchCase.endControlFlow()
-                .addStatement("return null").build();
-    }
+    return switchCase.endControlFlow().addStatement("return null").build();
+  }
 }

--- a/gwt-localizable-processor/src/main/java/org/gwtproject/i18n/processor/LocalizableProcessor.java
+++ b/gwt-localizable-processor/src/main/java/org/gwtproject/i18n/processor/LocalizableProcessor.java
@@ -1,21 +1,35 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.gwtproject.i18n.processor;
 
 import com.google.auto.common.BasicAnnotationProcessor;
 import com.google.auto.service.AutoService;
-
+import java.util.Collections;
 import javax.annotation.processing.Processor;
 import javax.lang.model.SourceVersion;
-import java.util.Collections;
 
 @AutoService(Processor.class)
 public class LocalizableProcessor extends BasicAnnotationProcessor {
-    @Override
-    public SourceVersion getSupportedSourceVersion() {
-        return SourceVersion.latestSupported();
-    }
+  @Override
+  public SourceVersion getSupportedSourceVersion() {
+    return SourceVersion.latestSupported();
+  }
 
-    @Override
-    protected Iterable<? extends ProcessingStep> initSteps() {
-        return Collections.singleton(new LocalizableProcessingStep(processingEnv));
-    }
+  @Override
+  protected Iterable<? extends ProcessingStep> initSteps() {
+    return Collections.singleton(new LocalizableProcessingStep(processingEnv));
+  }
 }

--- a/gwt-localizable-processor/src/test/java/org/gwtproject/i18n/client/AnnotationsTest.java
+++ b/gwt-localizable-processor/src/test/java/org/gwtproject/i18n/client/AnnotationsTest.java
@@ -15,143 +15,118 @@
  */
 package org.gwtproject.i18n.client;
 
-import com.google.gwt.core.client.GWT;
-import org.gwtproject.i18n.client.LocalizableResource.DefaultLocale;
 import com.google.gwt.junit.client.GWTTestCase;
+import org.gwtproject.i18n.client.LocalizableResource.DefaultLocale;
 import org.gwtproject.i18n.shared.Localizable;
 
-/**
- * Tests annotations not covered elsewhere.
- */
+/** Tests annotations not covered elsewhere. */
 public class AnnotationsTest extends GWTTestCase {
 
-    /**
-     * First grandparent for test.
-     */
-    public interface GP1 extends TestConstants {
-        @Constants.DefaultStringValue("gp1 annot")
-        String gp1();
+  /** First grandparent for test. */
+  public interface GP1 extends TestConstants {
+    @Constants.DefaultStringValue("gp1 annot")
+    String gp1();
 
-        @Constants.DefaultStringValue("gp1 shared annot")
-        String shared();
-    }
+    @Constants.DefaultStringValue("gp1 shared annot")
+    String shared();
+  }
 
-    /**
-     * Second grandparent for test.
-     */
-    public interface GP2 extends TestConstants {
-        @Constants.DefaultStringValue("gp2 annot")
-        String gp2();
+  /** Second grandparent for test. */
+  public interface GP2 extends TestConstants {
+    @Constants.DefaultStringValue("gp2 annot")
+    String gp2();
 
-        @Constants.DefaultStringValue("gp2 shared annot")
-        String shared();
-    }
+    @Constants.DefaultStringValue("gp2 shared annot")
+    String shared();
+  }
 
-    /**
-     * Test interface for P1 before P2.
-     */
-    @Localizable.IsLocalizable
-    public interface Inherit1 extends P1, P2 {
-    }
+  /** Test interface for P1 before P2. */
+  @Localizable.IsLocalizable
+  public interface Inherit1 extends P1, P2 {}
 
-    /**
-     * Test interface for P2 before P1.
-     */
-    @Localizable.IsLocalizable
-    public interface Inherit2 extends P2, P1 {
-        @Constants.DefaultStringValue("def")
-        String def();
-    }
+  /** Test interface for P2 before P1. */
+  @Localizable.IsLocalizable
+  public interface Inherit2 extends P2, P1 {
+    @Constants.DefaultStringValue("def")
+    String def();
+  }
 
-    /**
-     * Used to verify that we can explicitly localize messages in annotations.
-     */
-    @DefaultLocale("en")
-    public interface Inherit2_en extends Inherit2 {
-        @Override
-        @Constants.DefaultStringValue("en def")
-        String def();
-    }
+  /** Used to verify that we can explicitly localize messages in annotations. */
+  @DefaultLocale("en")
+  public interface Inherit2_en extends Inherit2 {
+    @Override
+    @Constants.DefaultStringValue("en def")
+    String def();
+  }
 
-    /**
-     * First parent interface for test.
-     */
-    public interface P1 extends TestConstants {
-        @Constants.DefaultStringValue("p1 annot")
-        String p1();
+  /** First parent interface for test. */
+  public interface P1 extends TestConstants {
+    @Constants.DefaultStringValue("p1 annot")
+    String p1();
 
-        @Constants.DefaultStringValue("p1 shared annot")
-        String shared();
-    }
+    @Constants.DefaultStringValue("p1 shared annot")
+    String shared();
+  }
 
-    /**
-     * Second parent interface for test.
-     */
-    public interface P2 extends GP1, GP2 {
-        @Constants.DefaultStringValue("p2 annot")
-        String p2();
-
-        @Override
-        String shared();
-    }
-
-    /**
-     * Basic test message.
-     */
-    public interface Msg1 extends Messages {
-        @DefaultMessage("Test {0}")
-        String getTest(String testName);
-    }
-
-    /**
-     * Plural form test message.
-     */
-    public interface Msg2 extends Messages {
-        @DefaultMessage("You have {0} widgets.")
-        @PluralText({"one", "You have a widget."})
-        String getWidgetCount(@PluralCount int count);
-
-        @DefaultMessage("from en")
-        String leastDerived();
-    }
-
-    /**
-     * Aggregate messages into one interface.
-     */
-    @Localizable.IsLocalizable
-    public interface AllMessages extends Msg1, Msg2 {
-    }
+  /** Second parent interface for test. */
+  public interface P2 extends GP1, GP2 {
+    @Constants.DefaultStringValue("p2 annot")
+    String p2();
 
     @Override
-    public String getModuleName() {
-        return null;//"org.gwtproject.i18n.I18NTest_en";
-    }
+    String shared();
+  }
 
-    public void testInheritance() {
-        Inherit1 i1 = Inherit1_Factory.create();
-        assertEquals("p1 annot", i1.p1());
-        assertEquals("gp2 annot", i1.gp2());
-        assertEquals("p1 shared annot", i1.shared());
-        Inherit2 i2 = Inherit2_Factory.create();
-        assertEquals("p1 annot", i2.p1());
-        assertEquals("gp2 annot", i2.gp2());
-        assertEquals("gp1 shared annot", i2.shared());
+  /** Basic test message. */
+  public interface Msg1 extends Messages {
+    @DefaultMessage("Test {0}")
+    String getTest(String testName);
+  }
 
-        // TODO(jat): this doesn't work because findDerivedClasses only
-        // looks for concrete classes, not other interfaces -- commenting
-        // out for now, revisit later.
-        // assertEquals("en def", i2.def());
-    }
+  /** Plural form test message. */
+  public interface Msg2 extends Messages {
+    @DefaultMessage("You have {0} widgets.")
+    @PluralText({"one", "You have a widget."})
+    String getWidgetCount(@PluralCount int count);
 
-    public void testIssue2359() {
-        AllMessages m = AllMessages_Factory.create();
-        assertEquals("Test foo", m.getTest("foo"));
-        assertEquals("You have 2 widgets.", m.getWidgetCount(2));
-        assertEquals("You have a widget.", m.getWidgetCount(1));
-    }
+    @DefaultMessage("from en")
+    String leastDerived();
+  }
 
-    public void testLeastDerived() {
-        AllMessages m = AllMessages_Factory.create();
-        assertEquals("from en_US", m.leastDerived());
-    }
+  /** Aggregate messages into one interface. */
+  @Localizable.IsLocalizable
+  public interface AllMessages extends Msg1, Msg2 {}
+
+  @Override
+  public String getModuleName() {
+    return null; // "org.gwtproject.i18n.I18NTest_en";
+  }
+
+  public void testInheritance() {
+    Inherit1 i1 = Inherit1_Factory.create();
+    assertEquals("p1 annot", i1.p1());
+    assertEquals("gp2 annot", i1.gp2());
+    assertEquals("p1 shared annot", i1.shared());
+    Inherit2 i2 = Inherit2_Factory.create();
+    assertEquals("p1 annot", i2.p1());
+    assertEquals("gp2 annot", i2.gp2());
+    assertEquals("gp1 shared annot", i2.shared());
+
+    // TODO(jat): this doesn't work because findDerivedClasses only
+    // looks for concrete classes, not other interfaces -- commenting
+    // out for now, revisit later.
+    // assertEquals("en def", i2.def());
+  }
+
+  public void testIssue2359() {
+    AllMessages m = AllMessages_Factory.create();
+    assertEquals("Test foo", m.getTest("foo"));
+    assertEquals("You have 2 widgets.", m.getWidgetCount(2));
+    assertEquals("You have a widget.", m.getWidgetCount(1));
+  }
+
+  public void testLeastDerived() {
+    AllMessages m = AllMessages_Factory.create();
+    assertEquals("from en_US", m.leastDerived());
+  }
 }

--- a/gwt-localizable-processor/src/test/java/org/gwtproject/i18n/client/TestConstants.java
+++ b/gwt-localizable-processor/src/test/java/org/gwtproject/i18n/client/TestConstants.java
@@ -17,8 +17,6 @@ package org.gwtproject.i18n.client;
 
 import org.gwtproject.i18n.client.LocalizableResource.Generate;
 
-import java.util.Map;
-
 /**
  * Interface to represent the contents of resourcePattern bundle
  * org/gwtproject/i18n/client/TestConstants.properties.
@@ -26,96 +24,96 @@ import java.util.Map;
 @Generate(format = "org.gwtproject.i18n.server.PropertyCatalogFactory")
 public interface TestConstants extends org.gwtproject.i18n.client.Constants {
 
-    boolean booleanFalse();
+  boolean booleanFalse();
 
-    boolean booleanTrue();
+  boolean booleanTrue();
 
-    double doubleNegMax();
+  double doubleNegMax();
 
-    double doubleNegMin();
+  double doubleNegMin();
 
-    double doubleNegOne();
+  double doubleNegOne();
 
-    double doubleOne();
+  double doubleOne();
 
-    double doublePi();
+  double doublePi();
 
-    double doublePosMax();
+  double doublePosMax();
 
-    double doublePosMin();
+  double doublePosMin();
 
-    double doubleZero();
+  double doubleZero();
 
-    float floatNegMax();
+  float floatNegMax();
 
-    float floatNegMin();
+  float floatNegMin();
 
-    float floatNegOne();
+  float floatNegOne();
 
-    float floatOne();
+  float floatOne();
 
-    float floatPi();
+  float floatPi();
 
-    float floatPosMax();
+  float floatPosMax();
 
-    float floatPosMin();
+  float floatPosMin();
 
-    float floatZero();
+  float floatZero();
 
-    @Key("string")
-    String getString();
+  @Key("string")
+  String getString();
 
-    int intMax();
+  int intMax();
 
-    int intMin();
+  int intMin();
 
-    int intNegOne();
+  int intNegOne();
 
-    int intOne();
+  int intOne();
 
-    int intZero();
+  int intZero();
 
-//    Map<String, String> mapABCD();
-//
-//    Map<String, String> mapBACD();
-//
-//    Map<String, String> mapBBB();
-//
-//    // raw type test
-//    @SuppressWarnings("unchecked")
-//    Map mapDCBA();
-//
-//    Map<String, String> mapEmpty();
-//
-//    // Map<String, String> mapWithMissingKey();
-//
-//    Map<String, String> mapXYZ();
-//
-//    String[] stringArrayABCDEFG();
-//
-//    String[] stringArraySizeOneEmptyString();
-//
-//    String[] stringArraySizeOneWithBackslashX();
-//
-//    String[] stringArraySizeOneX();
-//
-//    String[] stringArraySizeThreeAllEmpty();
-//
-//    String[] stringArraySizeThreeWithDoubleBackslash();
-//
-//    String[] stringArraySizeTwoBothEmpty();
-//
-//    String[] stringArraySizeTwoWithEscapedComma();
+  //    Map<String, String> mapABCD();
+  //
+  //    Map<String, String> mapBACD();
+  //
+  //    Map<String, String> mapBBB();
+  //
+  //    // raw type test
+  //    @SuppressWarnings("unchecked")
+  //    Map mapDCBA();
+  //
+  //    Map<String, String> mapEmpty();
+  //
+  //    // Map<String, String> mapWithMissingKey();
+  //
+  //    Map<String, String> mapXYZ();
+  //
+  //    String[] stringArrayABCDEFG();
+  //
+  //    String[] stringArraySizeOneEmptyString();
+  //
+  //    String[] stringArraySizeOneWithBackslashX();
+  //
+  //    String[] stringArraySizeOneX();
+  //
+  //    String[] stringArraySizeThreeAllEmpty();
+  //
+  //    String[] stringArraySizeThreeWithDoubleBackslash();
+  //
+  //    String[] stringArraySizeTwoBothEmpty();
+  //
+  //    String[] stringArraySizeTwoWithEscapedComma();
 
-    String stringDoesNotTrimTrailingThreeSpaces();
+  String stringDoesNotTrimTrailingThreeSpaces();
 
-    String stringEmpty();
+  String stringEmpty();
 
-    String stringJapaneseBlue();
+  String stringJapaneseBlue();
 
-    String stringJapaneseGreen();
+  String stringJapaneseGreen();
 
-    String stringJapaneseRed();
+  String stringJapaneseRed();
 
-    String stringTrimsLeadingWhitespace();
+  String stringTrimsLeadingWhitespace();
 }

--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,7 @@
         <module>gwt-i18n-processor-util</module>
         <module>gwt-i18n</module>
         <module>gwt-datetimeformat</module>
+        <module>gwt-localizable-processor</module>
     </modules>
 
 </project>


### PR DESCRIPTION
Also fixes an embarrassing dumb mistake where I forgot to actually include the newly created module in the last patch... This is the only actual code change, adding the missing `<module>` tags, everything else is just fixing whitespace and such automatically.